### PR TITLE
Fix argparse in CLI interface

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -62,7 +62,7 @@ def parse_args(args=None):
         help="Additional arguments to pass to Seqera Platform"
         " CLI enclosed in double quotes (e.g. '--cli=\"--insecure\"')",
     )
-    return parser.parse_args(args if args is not None else sys.argv[1:])
+    return parser.parse_args(args)
 
 
 class BlockParser:
@@ -124,7 +124,7 @@ class BlockParser:
 
 
 def main(args=None):
-    options = parse_args(args)
+    options = parse_args(args if args is not None else sys.argv[1:])
     logging.basicConfig(level=options.log_level)
 
     # Parse CLI arguments into a list


### PR DESCRIPTION
 Allows the main method to be called with custom arguments when imported as a module, which is necessary for cases like providing `--help` from another script or an interactive session.