### PR TITLE
fix: handling of cli errors and custom exp

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -23,7 +23,7 @@ import sys
 
 from pathlib import Path
 from seqerakit import seqeraplatform, helper, overwrite
-from seqerakit.seqeraplatform import ResourceExistsError
+from seqerakit.seqeraplatform import ResourceExistsError, ResourceCreationError
 
 
 logger = logging.getLogger(__name__)
@@ -152,9 +152,9 @@ def main(args=None):
             try:
                 # Run the 'tw' methods for each block
                 block_manager.handle_block(block, args, destroy=options.delete)
-            except ResourceExistsError as e:
+            except (ResourceExistsError, ResourceCreationError) as e:
                 logging.error(e)
-                continue
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -102,15 +102,20 @@ class SeqeraPlatform:
         return json.loads(stdout) if to_json else stdout
 
     def _handle_command_errors(self, stdout):
+        logging.error(stdout)
+
+        # Check for specific tw cli error patterns and raise custom exceptions
         if re.search(
             r"ERROR: .*already (exists|a participant)", stdout, flags=re.IGNORECASE
         ):
             raise ResourceExistsError(
                 " Resource already exists. Please delete first or set 'overwrite: true'"
             )
-        raise ResourceCreationError(
-            f"Resource creation failed: '{stdout}'. Check your config and try again."
-        )
+        else:
+            raise ResourceCreationError(
+                f" Resource creation failed: '{stdout}'. "
+                "Check your config and try again."
+            )
 
     def _tw_run(self, cmd, *args, **kwargs):
         full_cmd = self._construct_command(cmd, *args, **kwargs)


### PR DESCRIPTION
Small fix to the way we catch custom exceptions to pass the error message in the raise statement and log it before exiting downstream.