### PR TITLE
FIx overwrite

### DIFF
--- a/.github/workflows/overwrite-testing.yml
+++ b/.github/workflows/overwrite-testing.yml
@@ -1,0 +1,49 @@
+name: overwrite-testing
+run-name: Create all entities in Seqera Platform from end-to-end with seqerakit, then overwrite
+# This workflow can be triggered manually with GitHub actions workflow dispatch button.
+# It will automate the end-to-end creation all of the following entities in Seqera Platform.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-overwrite:
+    name:
+    if: github.repository == 'seqeralabs/seqera-kit'
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/biocontainers/seqerakit:latest
+    env:
+      SEQERA_ORGANIZATION_NAME: ${{ secrets.SEQERA_ORGANIZATION_NAME }}
+      SEQERA_TEAM_NAME: ${{ secrets.SEQERA_TEAM_NAME }}
+      SEQERA_WORKSPACE_NAME: ${{ secrets.SEQERA_WORKSPACE_NAME }}
+      TEAM_MEMBER_EMAIL1: ${{ secrets.TEAM_MEMBER_EMAIL1 }}
+      SEQERA_GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
+      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+      SEQERA_GITHUB_PASSWORD: ${{ secrets.TOWER_GITHUB_PASSWORD }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+      AWS_COMPUTE_ENV_NAME: ${{ secrets.AWS_COMPUTE_ENV_NAME }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      SEQERA_WORK_DIR: ${{ secrets.SEQERA_WORK_DIR }}
+      PIPELINE_NAME_PREFIX: ${{ secrets.PIPELINE_NAME_PREFIX }}
+      SENTIEON_LICENSE_BASE64: ${{ secrets.SENTIEON_LICENSE_BASE64 }}
+      DATASET_NAME_PREFIX: ${{ secrets.DATASET_NAME_PREFIX }}
+    steps:
+      - name: Check out source-code repository
+        uses: actions/checkout@v3
+
+      - name: Create all entities for AWS on Seqera Platform from end-to-end
+        run: |
+          seqerakit tests/e2e/aws-e2e.yml
+
+      - name: Overwrite all entities for AWS on Seqera Platform from end-to-end
+        run: |
+          seqerakit tests/e2e/aws-e2e.yml
+
+      - name: Delete all entities for AWS on Seqera Platform from end-to-end
+        run: |
+          seqerakit tests/e2e/aws-e2e.yml --delete

--- a/seqerakit/utils.py
+++ b/seqerakit/utils.py
@@ -65,8 +65,16 @@ def check_if_exists(json_data, namekey, namevalue):
     if not json_data:
         return False
 
+    if namevalue.startswith("$"):
+        env_var_name = namevalue[1:]
+        resolved_value = os.getenv(env_var_name)
+        if resolved_value is None:
+            raise ValueError(f"Environment variable '{env_var_name}' not found")
+    else:
+        resolved_value = namevalue
+
     data = json.loads(json_data)
-    if find_key_value_in_dict(data, namekey, namevalue, return_key=None):
+    if find_key_value_in_dict(data, namekey, resolved_value, return_key=None):
         return True
 
 

--- a/tests/e2e/aws-e2e.yml
+++ b/tests/e2e/aws-e2e.yml
@@ -1,0 +1,84 @@
+# Test overwrite of all entities
+organizations:
+  - name: '$SEQERA_ORGANIZATION_NAME'
+    full-name: '$SEQERA_ORGANIZATION_NAME'
+    description: 'Example of an organization'
+    overwrite: True
+teams:
+  - name: '$SEQERA_TEAM_NAME'
+    organization: '$SEQERA_ORGANIZATION_NAME'
+    description: 'Example of a team'
+    members:
+      - '$TEAM_MEMBER_EMAIL1'
+    overwrite: True
+workspaces:
+  - name: '$SEQERA_WORKSPACE_NAME'
+    full-name: '$SEQERA_WORKSPACE_NAME'
+    organization: '$SEQERA_ORGANIZATION_NAME'
+    visibility: 'PRIVATE'
+    overwrite: True
+participants:
+  - name: '$SEQERA_TEAM_NAME'
+    type: 'TEAM'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    role: 'ADMIN'
+    overwrite: True
+credentials:
+  - type: 'github'
+    name: 'github_credentials'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    username: '$SEQERA_GITHUB_USERNAME'
+    password: '$SEQERA_GITHUB_PASSWORD'
+    overwrite: True
+  - type: 'container-reg'
+    name: 'dockerhub_credentials'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    username: '$DOCKERHUB_USERNAME'
+    password: '$DOCKERHUB_PASSWORD'
+    registry: 'docker.io'
+    overwrite: True
+  - type: 'aws'
+    name: 'aws_credentials'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    access-key: '$AWS_ACCESS_KEY_ID'
+    secret-key: '$AWS_SECRET_ACCESS_KEY'
+    assume-role-arn: '$AWS_ASSUME_ROLE_ARN'
+    overwrite: True
+secrets:
+  - name: 'SENTIEON_LICENSE_BASE64'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    value: '$SENTIEON_LICENSE_BASE64'
+    overwrite: True
+compute-envs:
+  - type: aws-batch
+    config-mode: forge
+    name: '$AWS_COMPUTE_ENV_NAME'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    credentials: 'aws_credentials'
+    region: '$AWS_REGION'
+    work-dir: '$SEQERA_WORK_DIR'
+    provisioning-model: SPOT
+    fusion-v2: True
+    wave: True
+    fast-storage: True
+    instance-types: 'c6id.2xlarge'
+    no-ebs-auto-scale: True
+    max-cpus: 500
+    wait: AVAILABLE
+    overwrite: True
+datasets:
+  - name: '$DATASET_NAME_PREFIX-rnaseq-samples'
+    description: 'Samplesheet to run the nf-core/rnaseq pipeline from end-to-end'
+    header: true
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    file-path: '../examples/yaml/datasets/rnaseq_samples.csv'
+    overwrite: True
+pipelines:
+  - name: '$PIPELINE_NAME_PREFIX-hello-world'
+    url: 'https://github.com/nextflow-io/hello'
+    workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
+    description: 'Classic hello world script in Nextflow language.'
+    compute-env: '$AWS_COMPUTE_ENV_NAME'
+    work-dir: '$SEQERA_WORK_DIR'
+    revision: 'master'
+    overwrite: True


### PR DESCRIPTION
Addresses #87.

The `overwrite` class contains a method where it calls a generic utility function written to take json data, and a key-value pair to check if the value exists within a nested json. If an environment variable was specified for the `name: ` key in entities, it was not being resolved correctly when running this utility function. This has been fixed.

To test, run `seqerakit test.yaml` with the following and set $SEQERA_ORGANIZATION_NAME to anything:
```
organizations:
  - name: '$SEQERA_ORGANIZATION_NAME'
    full-name: '$SEQERA_ORGANIZATION_NAME'
    description: 'Organization created E2E with seqerakit CLI scripting'
    location: 'Global'
    website: 'https://seqera.io/'
    overwrite: True
 ```
 
 Re-run:
 ```
 DEBUG:root: Overwrite is set to 'True' for organizations

DEBUG:root: Running command: tw -o json organizations list
Checking for organizations with name $SEQERA_ORGANIZATION_NAME
DEBUG:root: The attempted organizations resource already exists. Overwriting.

DEBUG:root: Running command: tw organizations delete --name $SEQERA_ORGANIZATION_NAME
DEBUG:root: Running command: tw organizations add --name $SEQERA_ORGANIZATION_NAME --full-name $SEQERA_ORGANIZATION_NAME --description 'Organization created E2E with seqerakit CLI scripting' --location Global --website https://seqera.io/
```

Also adds a draft for GHA testing overwrite and `--delete`. This might need some more testing.