### PR TITLE
feat: add info flag and support for tw info

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -40,6 +40,11 @@ def parse_args(args=None):
         type=str.upper,
     )
     parser.add_argument(
+        "--info",
+        action="store_true",
+        help="Display information about the Seqera Platform and exit",
+    )
+    parser.add_argument(
         "--dryrun",
         action="store_true",
         help="Print the commands that would be executed without running them.",
@@ -47,7 +52,7 @@ def parse_args(args=None):
     parser.add_argument(
         "yaml",
         type=Path,
-        nargs="+",  # allow multiple YAML paths
+        nargs="*",  # allow multiple YAML paths
         help="One or more YAML files with Seqera Platform resources to create",
     )
     parser.add_argument(
@@ -126,6 +131,18 @@ class BlockParser:
 def main(args=None):
     options = parse_args(args if args is not None else sys.argv[1:])
     logging.basicConfig(level=options.log_level)
+
+    # If the info flag is set, run 'tw info'
+    if options.info:
+        sp = seqeraplatform.SeqeraPlatform()
+        print(sp.info())
+        return
+
+    if not options.yaml:
+        logging.error(
+            " No YAML(s) provided. Please provide atleast one YAML configuration file."
+        )
+        sys.exit(1)
 
     # Parse CLI arguments into a list
     cli_args_list = options.cli_args.split() if options.cli_args else []

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -101,6 +101,11 @@ class SeqeraPlatform:
 
         return json.loads(stdout) if to_json else stdout
 
+    def _execute_info_command(self):
+        # Directly execute 'tw info' command
+        command = "tw info"
+        return self._execute_command(command)
+
     def _handle_command_errors(self, stdout):
         logging.error(stdout)
 
@@ -126,7 +131,10 @@ class SeqeraPlatform:
 
     # Allow any 'tw' subcommand to be called as a method.
     def __getattr__(self, cmd):
-        return self.TwCommand(self, cmd.replace("_", "-"))
+        if cmd == "info":
+            return self._execute_info_command
+        else:
+            return self.TwCommand(self, cmd.replace("_", "-"))
 
 
 class ResourceExistsError(Exception):


### PR DESCRIPTION
Addresses #4 with added error handling if no YAMLs provided.

Test with:
```
seqerakit --info
```

Or, in a Python script:
```
from seqerakit import seqeraplatform

tw = seqeraplatform.SeqeraPlatform()
print(tw.info())
```