### PR TITLE
feat: support params and params-file keys

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
+          pip install pytest-mock
           pip install -e .
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@ conda activate seqerakit
 
 If you already have [Seqera Platform CLI](https://github.com/seqeralabs/tower-cli#1-installation) and Python installed on your system, you can install `seqerakit` directly from [PyPI](https://pypi.org/project/seqerakit/):
 
-
-```
+```console
 pip install seqerakit
 ```
 
 You can force overwrite the installation to use the latest changes with the command below:
 
-```
+```console
 pip install --upgrade --force-reinstall seqerakit
 ```
 
@@ -69,7 +68,7 @@ export TOWER_ACCESS_TOKEN=<your access token>
 
 Use the -h or --help parameter to list the available commands and their associated options:
 
-```
+```bash
 seqerakit -h
 ```
 
@@ -77,7 +76,7 @@ seqerakit -h
 
 To print the commands that would executed with `tw` when using a YAML file, you can run `seqerakit` with the `--dryrun` flag:
 
-```
+```bash
 seqerakit file.yaml --dryrun
 ```
 
@@ -85,7 +84,7 @@ seqerakit file.yaml --dryrun
 
 Instead of adding or creating resources, you can recursively delete resources in your YAML file by specifying the `--delete` flag:
 
-```
+```bash
 seqerakit file.yaml --delete
 ```
 
@@ -95,7 +94,7 @@ For example, if you have a YAML file that defines an Organization -> Workspace -
 
 `tw` specific CLI options can be specified with the `--cli=` flag:
 
-```
+```bash
 seqerakit file.yaml --cli="--arg1 --arg2"
 ```
 
@@ -107,7 +106,7 @@ To use `tw` specific CLI options such as `--insecure`, use the `--cli=` flag, fo
 
 For example:
 
-```
+```bash
 seqerakit file.yaml --cli="--insecure"
 ```
 
@@ -115,11 +114,44 @@ To use an SSL certificate that is not accepted by the default Java certificate a
 
 For example:
 
-```
+```bash
 seqerakit hello-world-config.yml --cli="-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts"
 ```
 
 <b>Note</b>: Use of `--verbose` option for the `tw` CLI is currently not supported by `seqerakit`. Supplying `--cli="--verbose"` will raise an error.
+
+## YAML Configuration Options
+
+There are several options that can be provided in your YAML configuration file, that are handled specially by seqerakit and not `tw` specific CLI options.
+
+### 1. Pipeline parameters using `params` and `params-file`
+
+To specify pipeline parameters, you may either use `params:` to specify a list of parameters, or use `params-file:` to point to a parameters file.
+
+For example, to specify pipeline parameters within your YAML:
+
+```yaml
+params:
+  outdir: 's3://path/to/outdir'
+  fasta: 's3://path/to/reference.fasta'
+```
+
+Alternatively, to specify a file containing pipeline parameters:
+
+```yaml
+params-file: '/path/to/my/parameters.yaml'
+```
+
+Optionally, you may provide both:
+
+```yaml
+params-file: '/path/to/my/parameters.yaml'
+params:
+  outdir: 's3://path/to/outdir'
+  fasta: 's3://path/to/reference.fasta'
+```
+
+If duplicate parameters are provided, the parameters in `params-file` will take precedence.
 
 ## Quick start
 
@@ -131,18 +163,18 @@ You will need to have an account on Seqera Platform (see [Plans and pricing](htt
 
 1. Create a YAML file called `hello-world-config.yml` with the contents below, and customise the `<YOUR_WORKSPACE>` and `<YOUR_COMPUTE_ENVIRONMENT>` entries as required:
 
-   ```
+   ```yaml
    launch:
-     - name: 'hello-world'                               # Workflow name
-       workspace: '<YOUR_WORKSPACE>'                     # Workspace name
-       compute-env: '<YOUR_COMPUTE_ENVIRONMENT>'         # Compute environment
-       revision: 'master'                                # Pipeline revision
-       pipeline: 'https://github.com/nextflow-io/hello'  # Pipeline URL
+     - name: 'hello-world' # Workflow name
+       workspace: '<YOUR_WORKSPACE>' # Workspace name
+       compute-env: '<YOUR_COMPUTE_ENVIRONMENT>' # Compute environment
+       revision: 'master' # Pipeline revision
+       pipeline: 'https://github.com/nextflow-io/hello' # Pipeline URL
    ```
 
 2. Launch the pipeline with `seqerakit`:
 
-   ```
+   ```bash
    seqerakit hello-world-config.yml
    ```
 
@@ -156,9 +188,9 @@ You can also launch the same pipeline via a Python script. This will essentially
 
 2. Launch the pipeline with `seqerakit`:
 
-   ```
+```bash
    python launch_hello_world.py
-   ```
+```
 
 3. Login to your Seqera Platform instance and check the Runs page in the appropriate Workspace for the pipeline you just launched!
 
@@ -168,7 +200,7 @@ Please see [`seqerakit-e2e.yml`](https://github.com/seqeralabs/seqera-kit/blob/m
 
 You can modify this YAML to similarly create Seqera Platform resources end-to-end for your setup. This YAML encodes environment variables to protect sensitive keys, usernames, and passwords that are required to create or add certain resources (i.e. credentials, compute environments). Prior to running it with `seqerakit examples/yaml/seqerakit-e2e.yml`, you will have to set the following environment variables:
 
-```
+```console
 $TOWER_GITHUB_PASSWORD
 $DOCKERHUB_PASSWORD
 $AWS_ACCESS_KEY_ID

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ You will need to have an account on Seqera Platform (see [Plans and pricing](htt
 
 1. Create a YAML file called `hello-world-config.yml` with the contents below, and customise the `<YOUR_WORKSPACE>` and `<YOUR_COMPUTE_ENVIRONMENT>` entries as required:
 
-   ```yaml
+   ```yaml # noqa
    launch:
-     - name: 'hello-world' # Workflow name
-       workspace: '<YOUR_WORKSPACE>' # Workspace name
-       compute-env: '<YOUR_COMPUTE_ENVIRONMENT>' # Compute environment
-       revision: 'master' # Pipeline revision
+     - name: 'hello-world'                              # Workflow name
+       workspace: '<YOUR_WORKSPACE>'                    # Workspace name
+       compute-env: '<YOUR_COMPUTE_ENVIRONMENT>'        # Compute environment
+       revision: 'master'                               # Pipeline revision
        pipeline: 'https://github.com/nextflow-io/hello' # Pipeline URL
    ```
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ params:
   fasta: 's3://path/to/reference.fasta'
 ```
 
-If duplicate parameters are provided, the parameters in `params-file` will take precedence.
+**Note**: If duplicate parameters are provided, the parameters provided as key-value pairs inside the `params` nested dictionary of the YAML file will take precedence.
 
 ## Quick start
 

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -218,6 +218,7 @@ def parse_pipelines_block(item):
     cmd_args = []
     repo_args = []
     params_args = []
+    params_file_path = None
 
     for key, value in item.items():
         if key == "url":
@@ -248,6 +249,8 @@ def parse_launch_block(item):
     repo_args = []
     cmd_args = []
     params_args = []
+    params_file_path = None
+
     for key, value in item.items():
         if key == "pipeline" or key == "url":
             repo_args.extend([str(value)])

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -247,16 +247,24 @@ def parse_pipelines_block(item):
 def parse_launch_block(item):
     repo_args = []
     cmd_args = []
+    params_args = []
     for key, value in item.items():
         if key == "pipeline" or key == "url":
             repo_args.extend([str(value)])
         elif key == "params":
-            temp_file_name = utils.create_temp_yaml(value)
-            cmd_args.extend(["--params-file", temp_file_name])
+            params_dict = value
+        elif key == "params-file":
+            params_file_path = str(value)
         else:
             cmd_args.extend([f"--{key}", str(value)])
-    cmd_args = repo_args + cmd_args
 
+    if "params" in item:
+        temp_file_name = utils.create_temp_yaml(
+            params_dict, params_file=params_file_path
+        )
+        params_args.extend(["--params-file", temp_file_name])
+
+    cmd_args = cmd_args + repo_args + params_args
     return cmd_args
 
 

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -223,8 +223,9 @@ def parse_pipelines_block(item):
         if key == "url":
             repo_args.extend([str(value)])
         elif key == "params":
-            temp_file_name = utils.create_temp_yaml(value)
-            params_args.extend(["--params-file", temp_file_name])
+            params_dict = value
+        elif key == "params-file":
+            params_file_path = str(value)
         elif key == "file-path":
             repo_args.extend([str(value)])
         elif isinstance(value, bool) and value:
@@ -232,9 +233,15 @@ def parse_pipelines_block(item):
         else:
             cmd_args.extend([f"--{key}", str(value)])
 
-    # First append the url related arguments then append the remaining ones
-    cmd_args = repo_args + params_args + cmd_args
-    return cmd_args
+    # Create the temporary YAML file after processing all items
+    if "params" in item:
+        temp_file_name = utils.create_temp_yaml(
+            params_dict, params_file=params_file_path
+        )
+        params_args.extend(["--params-file", temp_file_name])
+
+    combined_args = cmd_args + repo_args + params_args
+    return combined_args
 
 
 def parse_launch_block(item):

--- a/seqerakit/utils.py
+++ b/seqerakit/utils.py
@@ -111,10 +111,18 @@ def is_url(s):
         return False
 
 
-def create_temp_yaml(params_dict):
+def create_temp_yaml(params_dict, params_file=None):
     """
     Create a generic temporary yaml file given a dictionary
+    Optionally combine with contents from a JSON or YAML file if provided.
     """
+
+    def read_file(file_path):
+        with open(file_path, "r") as file:
+            if file_path.endswith(".json"):
+                return json.load(file)
+            else:
+                return yaml.safe_load(file)
 
     class quoted_str(str):
         pass
@@ -123,6 +131,13 @@ def create_temp_yaml(params_dict):
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
 
     yaml.add_representer(quoted_str, quoted_str_representer)
+
+    # If a params_file is provided, combine its contents with params_dict
+    if params_file:
+        file_params = read_file(params_file)
+        params_dict.update(file_params)
+
+    # Expand environment variables and quote strings
     params_dict = {
         k: quoted_str(os.path.expandvars(v)) if isinstance(v, str) else v
         for k, v in params_dict.items()
@@ -131,7 +146,7 @@ def create_temp_yaml(params_dict):
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".yaml"
     ) as temp_file:
-        yaml.dump(params_dict, temp_file)
+        yaml.dump(params_dict, temp_file, default_flow_style=False)
         return temp_file.name
 
 

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,42 +1,227 @@
-import unittest
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open
 from seqerakit import helper
+import yaml
+import pytest
 
-mocked_yaml = """
-datasets:
-  - name: 'test_dataset1'
-    description: 'My test dataset 1'
-    header: true
-    workspace: 'my_organization/my_workspace'
-    file-path: './examples/yaml/datasets/samples.csv'
-    overwrite: True
-"""
+# Fixture to mock a YAML file
+@pytest.fixture
+def mock_yaml_file(mocker):
+    def _mock_yaml_file(test_data, file_name="mock_file.yaml"):
+        # Convert test data to YAML format
+        yaml_content = yaml.dump(test_data, default_flow_style=False)
+        mock_file = mock_open(read_data=yaml_content)
+        mocker.patch("builtins.open", mock_file)
 
-mocked_file = mock_open(read_data=mocked_yaml)
+        return file_name
+
+    return _mock_yaml_file
 
 
-class TestYamlParserFunctions(unittest.TestCase):
-    @patch("builtins.open", mocked_file)
-    def test_parse_datasets_yaml(self):
-        result = helper.parse_all_yaml(["test_path.yaml"])
-        expected_block_output = [
+def test_create_mock_organization_yaml(mock_yaml_file):
+
+    test_data = {
+        "organizations": [
             {
-                "cmd_args": [
-                    "--header",
-                    "./examples/yaml/datasets/samples.csv",
-                    "--name",
-                    "test_dataset1",
-                    "--workspace",
-                    "my_organization/my_workspace",
-                    "--description",
-                    "My test dataset 1",
-                ],
+                "name": "test_organization1",
+                "full-name": "My test organization 1",
+                "description": "My test organization 1",
+                "location": "Global",
+                "url": "https://example.com",
                 "overwrite": True,
             }
         ]
+    }
+    expected_block_output = [
+        {
+            "cmd_args": [
+                "--description",
+                "My test organization 1",
+                "--full-name",
+                "My test organization 1",
+                "--location",
+                "Global",
+                "--name",
+                "test_organization1",
+                "--url",
+                "https://example.com",
+            ],
+            "overwrite": True,
+        }
+    ]
 
-        self.assertIn("datasets", result)
-        self.assertEqual(result["datasets"], expected_block_output)
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "organizations" in result
+    assert result["organizations"] == expected_block_output
 
 
-# TODO: add more tests for other functions in helper.py
+def test_create_mock_workspace_yaml(mock_yaml_file):
+
+    test_data = {
+        "workspaces": [
+            {
+                "name": "test_workspace1",
+                "full-name": "My test workspace 1",
+                "organization": "my_organization",
+                "description": "My test workspace 1",
+                "visibility": "PRIVATE",
+                "overwrite": True,
+            }
+        ]
+    }
+    expected_block_output = [
+        {
+            "cmd_args": [
+                "--description",
+                "My test workspace 1",
+                "--full-name",
+                "My test workspace 1",
+                "--name",
+                "test_workspace1",
+                "--organization",
+                "my_organization",
+                "--visibility",
+                "PRIVATE",
+            ],
+            "overwrite": True,
+        }
+    ]
+
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "workspaces" in result
+    assert result["workspaces"] == expected_block_output
+
+
+def test_create_mock_dataset_yaml(mock_yaml_file):
+
+    test_data = {
+        "datasets": [
+            {
+                "name": "test_dataset1",
+                "description": "My test dataset 1",
+                "workspace": "my_organization/my_workspace",
+                "header": True,
+                "file-path": "./examples/yaml/datasets/samples.csv",
+                "overwrite": True,
+            }
+        ]
+    }
+    expected_block_output = [
+        {
+            "cmd_args": [
+                "./examples/yaml/datasets/samples.csv",
+                "--name",
+                "test_dataset1",
+                "--workspace",
+                "my_organization/my_workspace",
+                "--description",
+                "My test dataset 1",
+                "--header",
+            ],
+            "overwrite": True,
+        }
+    ]
+
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "datasets" in result
+    assert result["datasets"] == expected_block_output
+
+
+def test_create_mock_computeevs_yaml(mock_yaml_file):
+
+    test_data = {
+        "compute-envs": [
+            {
+                "name": "test_computeenv",
+                "workspace": "my_organization/my_workspace",
+                "credentials": "my_credentials",
+                "file-path": "./examples/yaml/computeenvs/computeenvs.yaml",
+                "wait": "AVAILABLE",
+                "overwrite": True,
+            }
+        ],
+    }
+
+    expected_block_output = [
+        {
+            "cmd_args": [
+                "--credentials",
+                "my_credentials",
+                "./examples/yaml/computeenvs/computeenvs.yaml",
+                "--name",
+                "test_computeenv",
+                "--wait",
+                "AVAILABLE",
+                "--workspace",
+                "my_organization/my_workspace",
+            ],
+            "overwrite": True,
+        }
+    ]
+
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "compute-envs" in result
+    assert result["compute-envs"] == expected_block_output
+
+
+def test_create_mock_pipeline_add_yaml(mock_yaml_file):
+
+    test_data = {
+        "pipelines": [
+            {
+                "name": "test_pipeline1",
+                "url": "https://github.com/nf-core/test_pipeline1",
+                "workspace": "my_organization/my_workspace",
+                "description": "My test pipeline 1",
+                "compute-env": "my_computeenv",
+                "work-dir": "s3://work",
+                "profile": "test",
+                "params-file": "./examples/yaml/pipelines/test_pipeline1/params.yaml",
+                "config": "./examples/yaml/pipelines/test_pipeline1/config.txt",
+                "pre-run": "./examples/yaml/pipelines/test_pipeline1/pre_run.sh",
+                "revision": "master",
+                "overwrite": True,
+            }
+        ]
+    }
+
+    # params file cmds parsed separately
+    expected_block_output = [
+        {
+            "cmd_args": [
+                "--compute-env",
+                "my_computeenv",
+                "--config",
+                "./examples/yaml/pipelines/test_pipeline1/config.txt",
+                "--description",
+                "My test pipeline 1",
+                "--name",
+                "test_pipeline1",
+                "--pre-run",
+                "./examples/yaml/pipelines/test_pipeline1/pre_run.sh",
+                "--profile",
+                "test",
+                "--revision",
+                "master",
+                "--work-dir",
+                "s3://work",
+                "--workspace",
+                "my_organization/my_workspace",
+                "https://github.com/nf-core/test_pipeline1",
+            ],
+            "overwrite": True,
+        }
+    ]
+
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "pipelines" in result
+    assert result["pipelines"] == expected_block_output

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -3,6 +3,7 @@ from seqerakit import helper
 import yaml
 import pytest
 
+
 # Fixture to mock a YAML file
 @pytest.fixture
 def mock_yaml_file(mocker):
@@ -18,7 +19,6 @@ def mock_yaml_file(mocker):
 
 
 def test_create_mock_organization_yaml(mock_yaml_file):
-
     test_data = {
         "organizations": [
             {
@@ -57,7 +57,6 @@ def test_create_mock_organization_yaml(mock_yaml_file):
 
 
 def test_create_mock_workspace_yaml(mock_yaml_file):
-
     test_data = {
         "workspaces": [
             {
@@ -96,7 +95,6 @@ def test_create_mock_workspace_yaml(mock_yaml_file):
 
 
 def test_create_mock_dataset_yaml(mock_yaml_file):
-
     test_data = {
         "datasets": [
             {
@@ -133,7 +131,6 @@ def test_create_mock_dataset_yaml(mock_yaml_file):
 
 
 def test_create_mock_computeevs_yaml(mock_yaml_file):
-
     test_data = {
         "compute-envs": [
             {
@@ -172,7 +169,6 @@ def test_create_mock_computeevs_yaml(mock_yaml_file):
 
 
 def test_create_mock_pipeline_add_yaml(mock_yaml_file):
-
     test_data = {
         "pipelines": [
             {


### PR DESCRIPTION
Addresses #45 to support both `params` and `params-file` for `tw pipelines` and `tw launch`.

If both `params:` and `params-file:` path is specified in either block, a temp YAML containing combined values from both will be generated. If there are duplicate key-value pairs, the `params:` in YAML takes precedence.

For example:
```yaml
launch:
  - name: 'nf-core-rnaseq-skit-params-test'
    pipeline: 'nf-core-rnaseq'
    workspace: 'scidev/testing'
    params-file: './params/nf_core_rnaseq_params.yml' # contains outdir: "s3://scidev-eu-west-1/nf-core-rnaseq/results"
    params:
      skip_gtf_filter: true
```

The resultant parameters are:
```yaml
outdir: "s3://scidev-eu-west-1/nf-core-rnaseq/results"
skip_gtf_filter: true
```

If you specify duplicate keys in the `params` block:
```yaml
launch:
  - name: 'nf-core-rnaseq-skit-params-test'
    pipeline: 'nf-core-rnaseq'
    workspace: 'scidev/testing'
    params-file: './params/nf_core_rnaseq_params.yml' # contains outdir: "s3://scidev-eu-west-1/nf-core-rnaseq/results"
    params:
      skip_gtf_filter: true
      outdir: 's3://scidev-eu-west-1/nf-core-rnaseq/other_results'
```
The resultant params are still as `outdir` from `params-file` takes precedence:
```yaml
outdir: "s3://scidev-eu-west-1/nf-core-rnaseq/results"
skip_gtf_filter: true
```