### PR TITLE
update python-testing : execute on PR too

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -1,6 +1,9 @@
 name: Lint-and-test
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   lint:


### PR DESCRIPTION
Similar to what Wave and Nextflow do:
- https://github.com/seqeralabs/wave/blob/master/.github/workflows/build.yml
- https://github.com/nextflow-io/nextflow/blob/master/.github/workflows/build.yml

And to what I implemented yesterday for wave-cli and fusion.

What I had noticed is that PRs with single commit would not trigger the workflows, resulting for instance in skipped CI tests.
