### PR TITLE
feat: add better error handling for empty yaml

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -163,16 +163,19 @@ def main(args=None):
 
     # Parse the YAML file(s) by blocks
     # and get a dictionary of command line arguments
-    cmd_args_dict = helper.parse_all_yaml(options.yaml, destroy=options.delete)
-    for block, args_list in cmd_args_dict.items():
-        for args in args_list:
-            try:
-                # Run the 'tw' methods for each block
-                block_manager.handle_block(block, args, destroy=options.delete)
-            except (ResourceExistsError, ResourceCreationError) as e:
-                logging.error(e)
-                sys.exit(1)
-
+    try:
+        cmd_args_dict = helper.parse_all_yaml(options.yaml, destroy=options.delete)
+        for block, args_list in cmd_args_dict.items():
+            for args in args_list:
+                try:
+                    # Run the 'tw' methods for each block
+                    block_manager.handle_block(block, args, destroy=options.delete)
+                except (ResourceExistsError, ResourceCreationError) as e:
+                    logging.error(e)
+                    sys.exit(1)
+    except ValueError as e:
+        logging.error(e)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -177,5 +177,6 @@ def main(args=None):
         logging.error(e)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     main()

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -62,8 +62,10 @@ def parse_all_yaml(file_paths, destroy=False):
 
             # Check if the YAML file is empty or contains no valid data
             if data is None or not data:
-                raise ValueError(f" The YAML file '{file_path}' is empty or does not contain valid data.")
-            
+                raise ValueError(
+                    f" The file '{file_path}' is empty or does not contain valid data."
+                )
+
             for key, value in data.items():
                 if key in merged_data:
                     try:

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -59,6 +59,11 @@ def parse_all_yaml(file_paths, destroy=False):
     for file_path in file_paths:
         with open(file_path, "r") as f:
             data = yaml.safe_load(f)
+
+            # Check if the YAML file is empty or contains no valid data
+            if data is None or not data:
+                raise ValueError(f" The YAML file '{file_path}' is empty or does not contain valid data.")
+            
             for key, value in data.items():
                 if key in merged_data:
                     try:

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -228,3 +228,11 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
 
     assert "pipelines" in result
     assert result["pipelines"] == expected_block_output
+
+def test_empty_yaml_file(mock_yaml_file):
+    test_data = {}
+    file_path = mock_yaml_file(test_data)
+
+    with pytest.raises(ValueError) as e:
+        helper.parse_all_yaml([file_path])
+    assert f"The YAML file '{file_path}' is empty or does not contain valid data." in str(e.value)

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -236,7 +236,6 @@ def test_empty_yaml_file(mock_yaml_file):
 
     with pytest.raises(ValueError) as e:
         helper.parse_all_yaml([file_path])
-    assert (
-        f"The file '{file_path}' is empty or does not contain valid data."
-        in str(e.value)
+    assert f"The file '{file_path}' is empty or does not contain valid data." in str(
+        e.value
     )

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -237,6 +237,6 @@ def test_empty_yaml_file(mock_yaml_file):
     with pytest.raises(ValueError) as e:
         helper.parse_all_yaml([file_path])
     assert (
-        f"The YAML file '{file_path}' is empty or does not contain valid data."
+        f"The file '{file_path}' is empty or does not contain valid data."
         in str(e.value)
     )

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -229,10 +229,14 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
     assert "pipelines" in result
     assert result["pipelines"] == expected_block_output
 
+
 def test_empty_yaml_file(mock_yaml_file):
     test_data = {}
     file_path = mock_yaml_file(test_data)
 
     with pytest.raises(ValueError) as e:
         helper.parse_all_yaml([file_path])
-    assert f"The YAML file '{file_path}' is empty or does not contain valid data." in str(e.value)
+    assert (
+        f"The YAML file '{file_path}' is empty or does not contain valid data."
+        in str(e.value)
+    )


### PR DESCRIPTION
Closes #103 

Adds error handling for when an empty YAML file is provided in `helper.parse_all_yaml`.
