### PR TITLE
feat: add flag for emitting version info, refactor parseargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will need to have an account on Seqera Platform (see [Plans and pricing](htt
 
 `seqerakit` requires the following dependencies:
 
-1. [Seqera Platform CLI](https://github.com/seqeralabs/tower-cli#1-installation)
+1. [Seqera Platform CLI (`>=0.9.2`)](https://github.com/seqeralabs/tower-cli#1-installation)
 
 2. [Python (`>=3.8`)](https://www.python.org/downloads/)
 
@@ -87,16 +87,20 @@ export TOWER_ACCESS_TOKEN=<your access token>
 
 ## Usage
 
-To confirm the installation of `seqerakit`, configuration of the Seqera Platform CLI and connection is working as expected:
+To confirm the installation of `seqerakit`, configuration of the Seqera Platform CLI and connection to the Platform is working as expected. This will run the `tw info` command under the hood:
 
 ```bash
 seqerakit --info
 ```
 
-Use the `-h` or `--help `parameter to list the available commands and their associated options:
-
+Use the `--help` or `-h` parameter to list the available commands and their associated options:
 ```bash
 seqerakit --help
+```
+
+Use `--version` or `-v` to retrieve the current version of your seqerakit installation:
+```bash
+seqerakit --version
 ```
 
 ### Dryrun

--- a/seqerakit/__init__.py
+++ b/seqerakit/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata as importlib_metadata
+
+__version__ = importlib_metadata.version(__name__)

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -24,48 +24,63 @@ import sys
 from pathlib import Path
 from seqerakit import seqeraplatform, helper, overwrite
 from seqerakit.seqeraplatform import ResourceExistsError, ResourceCreationError
-
+from seqerakit import __version__
 
 logger = logging.getLogger(__name__)
 
 
 def parse_args(args=None):
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
+    parser = argparse.ArgumentParser(
+        description="Seqerakit: Python wrapper for the Seqera Platform CLI"
+    )
+    # General options
+    general = parser.add_argument_group("General Options")
+    general.add_argument(
         "-l",
         "--log_level",
         default="INFO",
         choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
-        help="The desired log level (default: INFO).",
-        type=str.upper,
+        help="Set the logging level.",
     )
-    parser.add_argument(
+    general.add_argument(
         "--info",
+        "-i",
         action="store_true",
-        help="Display information about the Seqera Platform and exit",
+        help="Display Seqera Platform information and exit.",
     )
-    parser.add_argument(
+    general.add_argument(
         "--dryrun",
+        "-d",
         action="store_true",
-        help="Print the commands that would be executed without running them.",
+        help="Print the commands that would be executed.",
     )
-    parser.add_argument(
+    general.add_argument(
+        "--version",
+        "-v",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Show version number and exit.",
+    )
+
+    # YAML processing options
+    yaml_processing = parser.add_argument_group("YAML Processing Options")
+    yaml_processing.add_argument(
         "yaml",
         type=Path,
-        nargs="*",  # allow multiple YAML paths
-        help="One or more YAML files with Seqera Platform resources to create",
+        nargs="*",
+        help="One or more YAML files with Seqera Platform resource definitions.",
     )
-    parser.add_argument(
+    yaml_processing.add_argument(
         "--delete",
         action="store_true",
-        help="Recursively delete all resources defined in the YAML file(s)",
+        help="Recursively delete resources defined in the YAML files.",
     )
-    parser.add_argument(
+    yaml_processing.add_argument(
         "--cli",
         dest="cli_args",
         type=str,
-        help="Additional arguments to pass to Seqera Platform"
-        " CLI enclosed in double quotes (e.g. '--cli=\"--insecure\"')",
+        help="Additional Seqera Platform CLI specific options to be passed,"
+        " enclosed in double quotes (e.g. '--cli=\"--insecure\"').",
     )
     return parser.parse_args(args)
 


### PR DESCRIPTION
Re #111 

- Adds flag to emit current version of seqerakit
- Refactor help flag to categorize seqerakit run commands vs YAML-specific processing commands
- Update README and add minimum version of CLI required