### PR TITLE
fix: fix duplicate name bug

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -105,7 +105,7 @@ class BlockParser:
         # Create an instance of Overwrite class
         self.overwrite_method = overwrite.Overwrite(self.sp)
 
-    def handle_block(self, block, args, destroy=False):
+    def handle_block(self, block, args, destroy=False, dryrun=False):
         # Check if delete is set to True, and call delete handler
         if destroy:
             logging.debug(" The '--delete' flag has been specified.\n")
@@ -127,12 +127,12 @@ class BlockParser:
 
         # Check if overwrite is set to True, and call overwrite handler
         overwrite_option = args.get("overwrite", False)
-        if overwrite_option:
+        if overwrite_option and dryrun is False:
             logging.debug(f" Overwrite is set to 'True' for {block}\n")
             self.overwrite_method.handle_overwrite(
                 block, args["cmd_args"], overwrite_option
             )
-        else:
+        elif dryrun is False:
             self.overwrite_method.handle_overwrite(block, args["cmd_args"])
 
         if block in self.list_for_add_method:
@@ -184,7 +184,9 @@ def main(args=None):
             for args in args_list:
                 try:
                     # Run the 'tw' methods for each block
-                    block_manager.handle_block(block, args, destroy=options.delete)
+                    block_manager.handle_block(
+                        block, args, destroy=options.delete, dryrun=options.dryrun
+                    )
                 except (ResourceExistsError, ResourceCreationError) as e:
                     logging.error(e)
                     sys.exit(1)

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -340,10 +340,19 @@ def handle_pipelines(sp, args):
 
 def find_name(cmd_args):
     """
-    Find and return the value associated with --name in the cmd_args list.
+    Find and return the value associated with --name in cmd_args, where cmd_args
+    can be a list, a tuple of lists, or nested lists/tuples.
     """
-    args_list = cmd_args.get("cmd_args", [])
-    for i in range(len(args_list) - 1):
-        if args_list[i] == "--name":
-            return args_list[i + 1]
-    return None
+
+    def search(args):
+        it = iter(args)
+        for arg in it:
+            if arg == "--name":
+                return next(it, None)
+            elif isinstance(arg, (list, tuple)):
+                result = search(arg)
+                if result is not None:
+                    return result
+        return None
+
+    return search(cmd_args.get("cmd_args", []))

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -202,7 +202,10 @@ class Overwrite:
         # Check if block data already exists
         if block in self.block_jsondata:
             self.cached_jsondata = self.block_jsondata[block]
-            sp_args = self._get_values_from_cmd_args(args, keys_to_get)
+            if block == "teams":
+                sp_args = self._get_values_from_cmd_args(args[0], keys_to_get)
+            else:
+                sp_args = self._get_values_from_cmd_args(args, keys_to_get)
         else:
             # Fetch the data if it does not exist
             if block == "teams":

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -266,6 +266,52 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
     assert result["pipelines"] == expected_block_output
 
 
+def test_mock_teams_yaml(mock_yaml_file):
+    test_data = {
+        "teams": [
+            {
+                "name": "test_team1",
+                "organization": "my_organization",
+                "description": "My test team 1",
+                "members": ["user1@org.io"],
+                "overwrite": True,
+            },
+        ]
+    }
+    expected_block_output = [
+        {
+            "cmd_args": (
+                [
+                    "--description",
+                    "My test team 1",
+                    "--name",
+                    "test_team1",
+                    "--organization",
+                    "my_organization",
+                ],
+                [
+                    [
+                        "--team",
+                        "test_team1",
+                        "--organization",
+                        "my_organization",
+                        "add",
+                        "--member",
+                        "user1@org.io",
+                    ]
+                ],
+            ),
+            "overwrite": True,
+        }
+    ]
+
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "teams" in result
+    assert result["teams"] == expected_block_output
+
+
 def test_empty_yaml_file(mock_yaml_file):
     test_data = {}
     file_path = mock_yaml_file(test_data)


### PR DESCRIPTION
Re #123

- Fixes method used to identify value associated with `name` key or `--name` argument and use value to identify duplicates 
- Disable any usage of overwrite method with `--dryrun`

Test with a yaml defining teams as following:

```yaml
teams:
  - name: "launchers"
    organization: "myorg"
    description: "Users with launcher permissions"
    overwrite: true
    members:
      - launcher@myorg.io
  - name: "viewers"
    organization: "myorg"
    description: "Users with viewer permissions"
    overwrite: true
    members:
      - viewer@myorg.io
```

Where running seqerakit will correctly provide dryrun output:
```console
$ seqerakit teams.yaml --dryrun
DEBUG:root:DRYRUN: Running command tw teams add --name launchers --organization myorg --description 'Users with launcher permissions'
DEBUG:root:DRYRUN: Running command tw teams members --team launchers --organization myorg add --member launcher@myorg.io
DEBUG:root:DRYRUN: Running command tw teams add --name viewers --organization myorg --description 'Users with viewer permissions'
DEBUG:root:DRYRUN: Running command tw teams members --team viewers --organization myorg add --member viewer@myorg.io
```