### PR TITLE
feat: add support for creating labels

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -169,6 +169,7 @@ def main(args=None):
         [
             "organizations",  # all use method.add
             "workspaces",
+            "labels",
             "credentials",
             "secrets",
             "actions",

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -82,6 +82,7 @@ def parse_all_yaml(file_paths, destroy=False):
         "organizations",
         "teams",
         "workspaces",
+        "labels",
         "participants",
         "credentials",
         "compute-envs",

--- a/templates/labels.yml
+++ b/templates/labels.yml
@@ -1,6 +1,6 @@
 ## To see the full list of options available run: "tw labels add"
 labels:
-  - name: 'label_name' # required
-    value: 'label_value' # required
-    workspace: 'my_organization/my_workspace' # required
-    overwrite: True # optional
+  - name: 'label_name'                          # required
+    value: 'label_value'                        # required
+    workspace: 'my_organization/my_workspace'   # required
+    overwrite: True                             # optional

--- a/templates/labels.yml
+++ b/templates/labels.yml
@@ -1,0 +1,6 @@
+## To see the full list of options available run: "tw labels add"
+labels:
+  - name: 'label_name' # required
+    value: 'label_value' # required
+    workspace: 'my_organization/my_workspace' # required
+    overwrite: True # optional


### PR DESCRIPTION
Re #125 to allow users to add resource labels to workspaces

- Update `helper.py` to parse `labels` with generic `add` method
- Add helper methods in `overwrite.py` to handle deletion of labels by their id
- Add a template yaml for labels