### PR TITLE
feat: add support for members

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -170,6 +170,7 @@ def main(args=None):
             "organizations",  # all use method.add
             "workspaces",
             "labels",
+            "members",
             "credentials",
             "secrets",
             "actions",

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -83,6 +83,7 @@ def parse_all_yaml(file_paths, destroy=False):
         "teams",
         "workspaces",
         "labels",
+        "members",
         "participants",
         "credentials",
         "compute-envs",

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -65,6 +65,11 @@ class Overwrite:
                 "method_args": self._get_label_args,
                 "name_key": "name",
             },
+            "members": {
+                "keys": ["user", "organization"],
+                "method_args": self._get_members_args,
+                "name_key": "email",
+            },
             "teams": {
                 "keys": ["name", "organization"],
                 "method_args": self._get_team_args,
@@ -106,6 +111,9 @@ class Overwrite:
                     self.block_operations["participants"]["name_key"] = "teamName"
                 else:
                     self.block_operations["participants"]["name_key"] = "email"
+            elif block == "members":
+                # Rename the user key to name to correctly index JSON data
+                sp_args["name"] = sp_args.pop("user")
             if self.check_resource_exists(operation["name_key"], sp_args):
                 # if resource exists and overwrite is true, delete
                 if overwrite:
@@ -149,6 +157,18 @@ class Overwrite:
             json.loads(json_out), "name", args["name"], "teamId"
         )
         return ("delete", "--id", str(team_id), "--organization", args["organization"])
+
+    def _get_members_args(self, args):
+        """
+        Returns a list of arguments for the delete() method for members.
+        """
+        return (
+            "delete",
+            "--user",
+            args["name"],
+            "--organization",
+            args["organization"],
+        )
 
     def _get_participant_args(self, args):
         """
@@ -234,6 +254,11 @@ class Overwrite:
                 sp_args = self._get_values_from_cmd_args(args, keys_to_get)
                 self.cached_jsondata = json_method(
                     block, "list", "-w", sp_args["workspace"]
+                )
+            elif block == "members":  # TODO
+                sp_args = self._get_values_from_cmd_args(args, keys_to_get)
+                self.cached_jsondata = json_method(
+                    block, "list", "-o", sp_args["organization"]
                 )
             else:
                 sp_args = self._get_values_from_cmd_args(args, keys_to_get)

--- a/templates/members.yml
+++ b/templates/members.yml
@@ -1,0 +1,5 @@
+## To see the full list of options available run: "tw members add"
+participants:
+  - user: 'bob@myorg.io'                           # required
+    organization: 'myorg'                          # required
+    overwrite: True                                # optional

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -266,7 +266,7 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
     assert result["pipelines"] == expected_block_output
 
 
-def test_mock_teams_yaml(mock_yaml_file):
+def test_create_mock_teams_yaml(mock_yaml_file):
     test_data = {
         "teams": [
             {
@@ -310,6 +310,26 @@ def test_mock_teams_yaml(mock_yaml_file):
 
     assert "teams" in result
     assert result["teams"] == expected_block_output
+
+
+def test_create_mock_members_yaml(mock_yaml_file):
+    test_data = {"members": [{"user": "bob@myorg.io", "organization": "myorg"}]}
+    expected_block_output = [
+        {
+            "cmd_args": [
+                "--organization",
+                "myorg",
+                "--user",
+                "bob@myorg.io",
+            ],
+            "overwrite": False,
+        }
+    ]
+    file_path = mock_yaml_file(test_data)
+    result = helper.parse_all_yaml([file_path])
+
+    assert "members" in result
+    assert result["members"] == expected_block_output
 
 
 def test_empty_yaml_file(mock_yaml_file):


### PR DESCRIPTION
Re #130, ability to create members in yaml. 

As an example:
```yaml
members:
  - user: "esha.joshi@seqera.io"
    organization: "seqerakit_automation"
    overwrite: True
```
```console
$ seqerakit members.yaml --dryrun
DEBUG:root:DRYRUN: Running command tw members add --user esha.joshi@seqera.io --organization seqerakit_automation
```