### PR TITLE
Fix uniqueness bug with dicts using keys other than name

### DIFF
--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -36,13 +36,14 @@ def parse_yaml_block(yaml_data, block_name):
     name_values = set()
 
     # Iterate over each item in the block.
+    # TODO: fix for resources that can be duplicate named in an org
     for item in block:
         cmd_args = parse_block(block_name, item)
         name = find_name(cmd_args)
         if name in name_values:
             raise ValueError(
-                f" Duplicate 'name' specified in config file"
-                f" for {block_name}: {name}. Please specify a unique name."
+                f" Duplicate name key specified in config file"
+                f" for {block_name}: {name}. Please specify a unique value."
             )
         name_values.add(name)
 
@@ -344,12 +345,22 @@ def find_name(cmd_args):
     """
     Find and return the value associated with --name in cmd_args, where cmd_args
     can be a list, a tuple of lists, or nested lists/tuples.
+
+    The function searches for the following keys: --name, --user, --email.
+
+    Parameters:
+    - cmd_args: The command arguments (list, tuple, or nested structures).
+
+    Returns:
+    - The value associated with the first key found, or None if none are found.
     """
+    # Predefined list of keys to search for
+    keys = {"--name", "--user", "--email"}
 
     def search(args):
         it = iter(args)
         for arg in it:
-            if arg == "--name":
+            if isinstance(arg, str) and arg in keys:
                 return next(it, None)
             elif isinstance(arg, (list, tuple)):
                 result = search(arg)

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -362,3 +362,35 @@ def test_error_type_yaml_file(mock_yaml_file):
         "Please specify at least 'type' or 'file-path' for creating the resource."
         in str(e.value)
     )
+
+
+def test_error_duplicate_name_yaml_file(mock_yaml_file):
+    test_data = {
+        "compute-envs": [
+            {
+                "name": "test_computeenv",
+                "workspace": "my_organization/my_workspace",
+                "credentials": "my_credentials",
+                "type": "aws-batch",
+                "config-mode": "forge",
+                "wait": "AVAILABLE",
+            },
+            {
+                "name": "test_computeenv",
+                "workspace": "my_organization/my_workspace",
+                "credentials": "my_credentials",
+                "type": "aws-batch",
+                "config-mode": "forge",
+                "wait": "AVAILABLE",
+            },
+        ],
+    }
+    file_path = mock_yaml_file(test_data)
+
+    with pytest.raises(ValueError) as e:
+        helper.parse_all_yaml([file_path])
+    assert (
+        "Duplicate name key specified in config file for " 
+        "compute-envs: test_computeenv. Please specify "
+        "a unique value." in str(e.value)
+    )

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -390,7 +390,7 @@ def test_error_duplicate_name_yaml_file(mock_yaml_file):
     with pytest.raises(ValueError) as e:
         helper.parse_all_yaml([file_path])
     assert (
-        "Duplicate name key specified in config file for " 
+        "Duplicate name key specified in config file for "
         "compute-envs: test_computeenv. Please specify "
         "a unique value." in str(e.value)
     )


### PR DESCRIPTION
Found with adding `members`, the result from `find_name()` returned none because the `--name` key does not exist. 

Resolved with defining keys to check membership for in items with strings or lists. Test with:
```yaml
members:
   - user: 'esha.joshi+owner@seqera.io'
     organization: '$TOWER_ORG_NAME'
     overwrite: True
   - user: 'esha.joshi+owner@seqera.io'
     organization: '$TOWER_ORG_NAME'
     overwrite: True
 ```
 
 Where dryrun returns:
 ```
 DEBUG:root:DRYRUN: Running command tw members add --user esha.joshi+owner@seqera.io --organization $TOWER_ORG_NAME
DEBUG:root:DRYRUN: Running command tw members add --user esha.joshi+maintain@seqera.io --organization $TOWER_ORG_NAME
```