### PR TITLE
fix: generate json data for workspaces with org argument for deletion

### DIFF
--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -255,7 +255,7 @@ class Overwrite:
                 self.cached_jsondata = json_method(
                     block, "list", "-w", sp_args["workspace"]
                 )
-            elif block == "members":  # TODO
+            elif block == "members" or block == "workspaces":  # TODO
                 sp_args = self._get_values_from_cmd_args(args, keys_to_get)
                 self.cached_jsondata = json_method(
                     block, "list", "-o", sp_args["organization"]

--- a/seqerakit/utils.py
+++ b/seqerakit/utils.py
@@ -66,7 +66,7 @@ def check_if_exists(json_data, namekey, namevalue):
     """
     if not json_data:
         return False
-    logging.info(f"Checking if {namekey} {namevalue} exists in Seqera Platform...")
+    logging.info(f" Checking if {namekey} {namevalue} exists in Seqera Platform...")
     # Regex pattern to match environment variables in the string
     env_var_pattern = re.compile(r"\$\{?[\w]+\}?")
 


### PR DESCRIPTION
Fix overwrite to use `organization` argument when generating list of workspaces in JSON data to use for deletion. Otherwise, there can be multiple workspaces of the same name across many organizations which will interfere with deletion.

