### PR TITLE
feat(SeqeraPlatform): seqerakit can write JSON to stdout for detailed records

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,17 @@ pip install --upgrade --force-reinstall seqerakit
 ```
 
 ### Local development installation
+
 You can install the development branch of `seqerakit` on your local machine to test feature updates of the tool. Before proceeding, ensure that you have [Python](https://www.python.org/downloads/) and [Git](https://git-scm.com/downloads) installed on your system.
 
 1. To install directly from pip:
+
 ```bash
 pip install git+https://github.com/seqeralabs/seqera-kit.git@dev
 ```
 
 2. Alternatively, you may clone the repository locally and install manually:
+
 ```bash
 git clone https://github.com/seqeralabs/seqera-kit.git
 cd seqera-kit
@@ -70,6 +73,7 @@ pip install .
 ```
 
 You can verify your installation with:
+
 ```bash
 pip show seqerakit
 ```
@@ -85,11 +89,12 @@ export TOWER_ACCESS_TOKEN=<Your access token>
 ```
 
 For Enterprise installations of Seqera Platform, you will also need to configure the API endpoint that will be used to connect to the Platform. You can do so by exporting the following environment variable:
+
 ```bash
 export TOWER_API_ENDPOINT=<Tower API URL>
 ```
-By default, this is set to `https://api.cloud.seqera.io` to connect to Seqera Platform Cloud.
 
+By default, this is set to `https://api.cloud.seqera.io` to connect to Seqera Platform Cloud.
 
 ## Usage
 
@@ -100,25 +105,33 @@ seqerakit --info
 ```
 
 Use the `--help` or `-h` parameter to list the available commands and their associated options:
+
 ```bash
 seqerakit --help
 ```
 
 Use `--version` or `-v` to retrieve the current version of your seqerakit installation:
+
 ```bash
 seqerakit --version
 ```
+
 ### Input
+
 `seqerakit` supports input through either file paths to YAMLs or directly from standard input (stdin).
 
 #### Using File Path
+
 ```bash
 seqerakit /path/to/file.yaml
 ```
+
 #### Using stdin
+
 ```console
 $ cat file.yaml | seqerakit -
 ```
+
 See the [Defining your YAML file using CLI options](#defining-your-yaml-file-using-cli-options) section for guidance on formatting your input YAML file(s).
 
 ### Dryrun
@@ -127,6 +140,29 @@ To print the commands that would executed with `tw` when using a YAML file, you 
 
 ```bash
 seqerakit file.yaml --dryrun
+```
+
+### JSON output
+
+If you wish to capture the details of the resources made, you can use the command line flag `--json` to write a JSON output to stdout. This is equivalent to using the `-o json` flag on the tw CLI.
+
+```console
+seqerakit -j examples/yaml/e2e/launch.yml
+INFO:root: Running command: tw -o json launch --name hello --workspace $SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME hello
+{"workflowId": "1wfhRp5ioFIyrs", "workflowUrl": "https://tower.nf/orgs/orgName/workspaces/workspaceName/watch/1wfhRp5ioFIyrs", "workspaceId": 12345678, "workspaceRef": "[orgName / workspaceName]"}
+```
+
+This will allow you to pipe the output into downstream tools. The logs will continue to be written to stderr, allowing you to monitor the progress of the tool.
+
+```console
+seqerakit -j examples/yaml/e2e/launch.yml > /dev/null
+INFO:root: Running command: tw -o json launch --name hello --workspace $SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME hello
+```
+
+Each invocation of the `tw` CLI will create a single JSON object. If you wish to collate them into one JSON object use a tool like jq:
+
+```console
+seqerakit -j launch/*.yml | jq --slurp > launched-pipelines.json
 ```
 
 ### Recursively delete
@@ -170,6 +206,7 @@ seqerakit hello-world-config.yml --cli="-Djavax.net.ssl.trustStore=/absolute/pat
 <b>Note</b>: Use of `--verbose` option for the `tw` CLI is currently not supported by `seqerakit`. Supplying `--cli="--verbose"` will raise an error.
 
 ## Specify targets
+
 When using a YAML file as input that defines multiple resources, you can use the `--targets` flag to specify which resources to create. This flag takes a comma-separated list of resource names.
 
 For example, given a YAML file that defines the following resources:
@@ -178,18 +215,17 @@ For example, given a YAML file that defines the following resources:
 workspaces:
   - name: 'showcase'
     organization: 'seqerakit_automation'
-...
+---
 compute-envs:
   - name: 'compute-env'
     type: 'aws-batch forge'
     workspace: 'seqerakit/test'
-...
+---
 pipelines:
-  - name: "hello-world-test-seqerakit"
-    url: "https://github.com/nextflow-io/hello"
+  - name: 'hello-world-test-seqerakit'
+    url: 'https://github.com/nextflow-io/hello'
     workspace: 'seqerakit/test'
-    compute-env: "compute-env"
-...
+    compute-env: 'compute-env'
 ```
 
 You can target the creation of `pipelines` only by running:
@@ -197,9 +233,11 @@ You can target the creation of `pipelines` only by running:
 ```bash
 seqerakit test.yml --targets pipelines
 ```
+
 This will process only the pipelines block from the YAML file and ignore other blocks such as `workspaces` and `compute-envs`.
 
 ### Multiple Targets
+
 You can also specify multiple resources to create by separating them with commas. For example, to create both workspaces and pipelines, run:
 
 ```bash
@@ -240,6 +278,7 @@ params:
 **Note**: If duplicate parameters are provided, the parameters provided as key-value pairs inside the `params` nested dictionary of the YAML file will take precedence **over** values in the provided `params-file`.
 
 ### 2. `overwrite` Functionality
+
 For every entity defined in your YAML file, you can specify `overwrite: True` to overwrite any existing entities in Seqera Platform of the same name.
 
 `seqerakit` will first check to see if the name of the entity exists, if so, it will invoke a `tw <subcommand> delete` command before attempting to create it based on the options defined in the YAML file.
@@ -253,21 +292,22 @@ DEBUG:root: The attempted organizations resource already exists. Overwriting.
 DEBUG:root: Running command: tw organizations delete --name $SEQERA_ORGANIZATION_NAME
 DEBUG:root: Running command: tw organizations add --name $SEQERA_ORGANIZATION_NAME --full-name $SEQERA_ORGANIZATION_NAME --description 'Example of an organization'
 ```
+
 ### 3. Specifying JSON configuration files with `file-path`
+
 The Seqera Platform CLI allows export and import of entities through JSON configuration files for pipelines and compute environments. To use these files to add a pipeline or compute environment to a workspace, use the `file-path` key to specify a path to a JSON configuration file.
 
 An example of the `file-path` option is provided in the [compute-envs.yml](./templates/compute-envs.yml) template:
 
 ```yaml
 compute-envs:
-  - name: 'my_aws_compute_environment'                              # required
-    workspace: 'my_organization/my_workspace'                       # required
-    credentials: 'my_aws_credentials'                               # required
-    wait: 'AVAILABLE'                                               # optional
-    file-path: './compute-envs/my_aws_compute_environment.json'     # required
+  - name: 'my_aws_compute_environment' # required
+    workspace: 'my_organization/my_workspace' # required
+    credentials: 'my_aws_credentials' # required
+    wait: 'AVAILABLE' # optional
+    file-path: './compute-envs/my_aws_compute_environment.json' # required
     overwrite: True
 ```
-
 
 ## Quick start
 
@@ -281,10 +321,10 @@ You will need to have an account on Seqera Platform (see [Plans and pricing](htt
 
    ```yaml # noqa
    launch:
-     - name: 'hello-world'                              # Workflow name
-       workspace: '<YOUR_WORKSPACE>'                    # Workspace name
-       compute-env: '<YOUR_COMPUTE_ENVIRONMENT>'        # Compute environment
-       revision: 'master'                               # Pipeline revision
+     - name: 'hello-world' # Workflow name
+       workspace: '<YOUR_WORKSPACE>' # Workspace name
+       compute-env: '<YOUR_COMPUTE_ENVIRONMENT>' # Compute environment
+       revision: 'master' # Pipeline revision
        pipeline: 'https://github.com/nextflow-io/hello' # Pipeline URL
    ```
 
@@ -340,6 +380,7 @@ Options:
       --revision=<revision>                A valid repository commit Id, tag or branch name.
   ...
 ```
+
 2. Define Key-Value Pairs in YAML
 
 Translate each CLI option into a key-value pair in the YAML file. The structure of your YAML file should reflect the hierarchy and format of the CLI options. For instance:
@@ -364,11 +405,11 @@ In this example:
 - The corresponding values are user-defined
 
 ### Best Practices:
+
 - Ensure that the indentation and structure of the YAML file are correct - YAML is sensitive to formatting.
 - Use quotes around strings that contain special characters or spaces.
 - When listing multiple values (`labels`, `instance-types`, `allow-buckets`, etc), separate them with commas as shown above.
 - For complex configurations, refer to the [Templates](./templates/) provided in this repository.
-
 
 ## Templates
 

--- a/README.md
+++ b/README.md
@@ -142,28 +142,52 @@ To print the commands that would executed with `tw` when using a YAML file, you 
 seqerakit file.yaml --dryrun
 ```
 
-### JSON output
+To capture the details of the created resources, you can use the `--json` command-line flag to output the results as JSON to `stdout`. This is equivalent to using the `-o json` flag with the `tw` CLI.
 
-If you wish to capture the details of the resources made, you can use the command line flag `--json` to write a JSON output to stdout. This is equivalent to using the `-o json` flag on the tw CLI.
+For example:
 
-```console
+```bash
 seqerakit -j examples/yaml/e2e/launch.yml
-INFO:root: Running command: tw -o json launch --name hello --workspace $SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME hello
-{"workflowId": "1wfhRp5ioFIyrs", "workflowUrl": "https://tower.nf/orgs/orgName/workspaces/workspaceName/watch/1wfhRp5ioFIyrs", "workspaceId": 12345678, "workspaceRef": "[orgName / workspaceName]"}
 ```
 
-This will allow you to pipe the output into downstream tools. The logs will continue to be written to stderr, allowing you to monitor the progress of the tool.
+This command internally runs the following `tw` command:
 
-```console
+```bash
+INFO:root: Running command: tw -o json launch --name hello --workspace $SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME hello
+```
+
+The output will look like this:
+
+```json
+{
+  "workflowId": "1wfhRp5ioFIyrs",
+  "workflowUrl": "https://tower.nf/orgs/orgName/workspaces/workspaceName/watch/1wfhRp5ioFIyrs",
+  "workspaceId": 12345678,
+  "workspaceRef": "[orgName / workspaceName]"
+}
+```
+
+This JSON output can be piped into other tools for further processing. Note that logs will still be written to `stderr`, allowing you to monitor the tool's progress in real-time.
+
+If you prefer to suppress the JSON output and focus only on the logs:
+
+```bash
 seqerakit -j examples/yaml/e2e/launch.yml > /dev/null
+```
+
+This will still log:
+
+```bash
 INFO:root: Running command: tw -o json launch --name hello --workspace $SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME hello
 ```
 
-Each invocation of the `tw` CLI will create a single JSON object. If you wish to collate them into one JSON object use a tool like jq:
+Each execution of the `tw` CLI generates a single JSON object. To combine multiple JSON objects into one, you can use a tool like `jq`:
 
-```console
+```bash
 seqerakit -j launch/*.yml | jq --slurp > launched-pipelines.json
 ```
+
+This command will merge the individual JSON objects from each `tw` command into a single JSON array and save it to `launched-pipelines.json`.
 
 ### Recursively delete
 

--- a/examples/python/launch_hello_world.py
+++ b/examples/python/launch_hello_world.py
@@ -28,5 +28,4 @@ pipeline_run = tw.launch(
     "--wait",
     "SUBMITTED",
     "https://github.com/nextflow-io/hello",
-    to_json=True,
 )

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -48,6 +48,9 @@ def parse_args(args=None):
         help="Display Seqera Platform information and exit.",
     )
     general.add_argument(
+        "-j", "--json", action="store_true", help="Output JSON format in stdout."
+    )
+    general.add_argument(
         "--dryrun",
         "-d",
         action="store_true",
@@ -164,7 +167,9 @@ def main(args=None):
     # Parse CLI arguments into a list
     cli_args_list = options.cli_args.split() if options.cli_args else []
 
-    sp = seqeraplatform.SeqeraPlatform(cli_args=cli_args_list, dryrun=options.dryrun)
+    sp = seqeraplatform.SeqeraPlatform(
+        cli_args=cli_args_list, dryrun=options.dryrun, json=options.json
+    )
 
     block_manager = BlockParser(
         sp,

--- a/seqerakit/computeenvs.py
+++ b/seqerakit/computeenvs.py
@@ -49,4 +49,4 @@ class ComputeEnvs(SeqeraPlatform):
         ]
 
         # Pass the built command to the base class method in SeqeraPlatform
-        return self._tw_run(command, *args, **kwargs, to_json=True)
+        return self._tw_run(command, *args, **kwargs)

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -113,7 +113,8 @@ class SeqeraPlatform:
             print_stdout if print_stdout is not None else self.print_stdout
         ) and not self._suppress_output
 
-        if should_print:
+        # Do not print output in logging if self.json is enabled
+        if should_print and not self.json:
             logging.info(f" Command output: {stdout}")
 
         if "ERROR: " in stdout or process.returncode != 0:

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -119,7 +119,7 @@ class SeqeraPlatform:
         if "ERROR: " in stdout or process.returncode != 0:
             self._handle_command_errors(stdout)
 
-        if self.json:
+        if self.json or to_json:
             out = json.loads(stdout)
             print(json.dumps(out))
         else:

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -332,6 +332,13 @@ class TestSeqeraPlatformOutputHandling(unittest.TestCase):
         result = self.sp._execute_command("tw pipelines list", to_json=False)
         self.assertEqual(result, '{"key": "value"}')
 
+        _sp = seqeraplatform.SeqeraPlatform(json=True)
+        result = _sp._execute_command("tw pipelines list", to_json=False)
+        self.assertEqual(result, {"key": "value"})
+
+        result = _sp._execute_command("tw pipelines list", to_json=True)
+        self.assertEqual(result, {"key": "value"})
+
     @patch("subprocess.Popen")
     def test_print_stdout_override(self, mock_subprocess):
         mock_subprocess.return_value = MagicMock(returncode=0)

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -8,7 +8,7 @@ import os
 
 class TestSeqeraPlatform(unittest.TestCase):
     def setUp(self):
-        self.sp = seqeraplatform.SeqeraPlatform()
+        self.sp = seqeraplatform.SeqeraPlatform(json=True)
 
     @patch("subprocess.Popen")
     def test_run_with_jsonout_command(self, mock_subprocess):
@@ -36,7 +36,7 @@ class TestSeqeraPlatform(unittest.TestCase):
         command = getattr(self.sp, "pipelines")
 
         # Run the command with arguments
-        result = command("view", "--name", "pipeline_name", to_json=True)
+        result = command("view", "--name", "pipeline_name")
 
         # Check that Popen was called with the right arguments
         mock_subprocess.assert_called_once_with(
@@ -103,7 +103,7 @@ class TestSeqeraPlatform(unittest.TestCase):
             command = getattr(self.sp, "pipelines")
 
             # Check that the JSON is parsed correctly
-            self.assertEqual(command("arg1", "arg2", to_json=True), {"key": "value"})
+            self.assertEqual(command("arg1", "arg2"), {"key": "value"})
 
 
 class TestSeqeraPlatformCLIArgs(unittest.TestCase):
@@ -121,7 +121,7 @@ class TestSeqeraPlatformCLIArgs(unittest.TestCase):
         )
 
         # Call a method
-        self.sp.pipelines("view", "--name", "pipeline_name", to_json=True)
+        self.sp.pipelines("view", "--name", "pipeline_name")
 
         # Extract the command used to call Popen
         called_command = mock_subprocess.call_args[0][0]
@@ -146,7 +146,7 @@ class TestSeqeraPlatformCLIArgs(unittest.TestCase):
         )
 
         # Call a method
-        self.sp.pipelines("view", "--name", "pipeline_name", to_json=True)
+        self.sp.pipelines("view", "--name", "pipeline_name")
 
         # Extract the command used to call Popen
         called_command = mock_subprocess.call_args[0][0]
@@ -178,7 +178,7 @@ class TestKitOptions(unittest.TestCase):
     @patch("subprocess.Popen")
     def test_dryrun_call(self, mock_subprocess):
         # Run a method with dryrun=True
-        self.dryrun_tw.pipelines("view", "--name", "pipeline_name", to_json=True)
+        self.dryrun_tw.pipelines("view", "--name", "pipeline_name")
 
         # Assert that subprocess.Popen is not called
         mock_subprocess.assert_not_called()


### PR DESCRIPTION
We needed a method of storing run info from the seqerakit CLI. After this change, you can use the '--json' flag to write the JSON return from the CLI to STDOUT. This can be captured and used in a different process or piped. This is enabled by a new command line flag, --json but should be possible when instantiating the SeqeraPlatform class in Python. The to_json kwarg is removed and replaced with this method so this might break some uses. The JSON is an attribute of the class and can be referenced whenever you use the SeqeraPlatform class.

BREAKING CHANGE: This could break anyone using the Python implementation with `to_json=True`. This is mainly [me](https://github.com/seqeralabs/showcase-automation/blob/528487f5d04d1207fa895d5ca9e398de2ecc0853/launch_pipelines.py#L154).

To use, try running seqerakit with the flag `-j` and piping:

```bash
seqerakit -j launch/*.yml | jq --slurp > launched-pipelines.json
```

(update): Because the function is overlapping with `to_json`, we just use either will create JSON output. If `to_json` is used it will print to stderr, if `-j` is used it will write to stdout suitable for piping.