### PR TITLE
fix: add handling for empty strings in key-value pairs of yaml

### DIFF
--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -67,7 +67,18 @@ class SeqeraPlatform:
         if "params_file" in kwargs:
             command.append(f"--params-file={kwargs['params_file']}")
 
+        # Check for empty string arguments and handle them
+        self._check_empty_args(command)
+
         return self._check_env_vars(command)
+
+    def _check_empty_args(self, command):
+        for current_arg, next_arg in zip(command, command[1:]):
+            if isinstance(next_arg, str) and next_arg.strip() == "":
+                raise ValueError(
+                    f"Empty string argument found for parameter '{current_arg}'. "
+                    "Please provide a valid value or remove the argument."
+                )
 
     # Checks environment variables to see that they are set accordingly
     def _check_env_vars(self, command):

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -91,6 +91,22 @@ class TestSeqeraPlatform(unittest.TestCase):
             with self.assertRaises(seqeraplatform.ResourceCreationError):
                 command("import", "my_pipeline.json", "--name", "pipeline_name")
 
+    def test_empty_string_argument(self):
+        command = ["--profile", " ", "--config", "my_config"]
+        with self.assertRaises(ValueError) as context:
+            self.sp._check_empty_args(command)
+        self.assertIn(
+            "Empty string argument found for parameter '--profile'",
+            str(context.exception),
+        )
+
+    def test_no_empty_string_argument(self):
+        command = ["--profile", "test_profile", "--config", "my_config"]
+        try:
+            self.sp._check_empty_args(command)
+        except ValueError:
+            self.fail("_check_empty_args() raised ValueError unexpectedly!")
+
     def test_json_parsing(self):
         with patch("subprocess.Popen") as mock_subprocess:
             # Mock the stdout of the Popen process to return JSON


### PR DESCRIPTION
Fix #149 to add handling if empty strings are provided as arguments. Throws a `ValueError` and indicates which arg/parameter was provided an empty string value for.