### PR TITLE
fix: remove defaults channel from install and build

### DIFF
--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -36,7 +36,7 @@ jobs:
           environment-file: environment.yml
           python-version: '3.12'
           mamba-version: '*'
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
           activate-environment: seqerakit
           use-mamba: true
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ You will need to have an account on Seqera Platform (see [Plans and pricing](htt
 You can install `seqerakit` and its dependencies via Conda. Ensure that you have the correct channels configured:
 
 ```console
-conda config --add channels defaults
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,9 @@
+name: seqerakitdev
+channels:
+  - bioconda
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::python=3.10.9
+  - conda-forge::pyyaml=6.0
+  - bioconda::tower-cli=0.9.2

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,7 +2,6 @@ name: seqerakitdev
 channels:
   - bioconda
   - conda-forge
-  - bioconda
 dependencies:
   - conda-forge::python=3.10.9
   - conda-forge::pyyaml=6.0


### PR DESCRIPTION
re #150, removes conda `defaults` channel from README, `environment.yaml` and GH workflow channels. 