### PR TITLE
fix: improve logic to respect cli and dryrun flags with info

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -145,10 +145,15 @@ def main(args=None):
     options = parse_args(args if args is not None else sys.argv[1:])
     logging.basicConfig(level=options.log_level)
 
+    # Parse CLI arguments into a list and create a Seqera Platform instance
+    cli_args_list = options.cli_args.split() if options.cli_args else []
+    sp = seqeraplatform.SeqeraPlatform(cli_args=cli_args_list, dryrun=options.dryrun)
+
     # If the info flag is set, run 'tw info'
     if options.info:
-        sp = seqeraplatform.SeqeraPlatform()
-        print(sp.info())
+        result = sp.info()
+        if not options.dryrun:
+            print(result)
         return
 
     if not options.yaml:
@@ -160,11 +165,6 @@ def main(args=None):
             sys.exit(1)
         else:
             options.yaml = [sys.stdin]
-
-    # Parse CLI arguments into a list
-    cli_args_list = options.cli_args.split() if options.cli_args else []
-
-    sp = seqeraplatform.SeqeraPlatform(cli_args=cli_args_list, dryrun=options.dryrun)
 
     block_manager = BlockParser(
         sp,

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -112,10 +112,10 @@ class SeqeraPlatform:
 
         return json.loads(stdout) if to_json else stdout
 
-    def _execute_info_command(self):
+    def _execute_info_command(self, *args, **kwargs):
         # Directly execute 'tw info' command
-        command = "tw info"
-        return self._execute_command(command)
+        command = ["info"]
+        return self._tw_run(command, *args, **kwargs)
 
     def _handle_command_errors(self, stdout):
         logging.error(stdout)

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -186,6 +186,32 @@ class TestSeqeraPlatformCLIArgs(unittest.TestCase):
             "--verbose is not supported as a CLI argument to seqerakit.",
         )
 
+    @patch("subprocess.Popen")
+    def test_info_command_construction(self, mock_subprocess):
+        # Mock the subprocess call to prevent actual execution
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        mock_subprocess.return_value.communicate.return_value = (b"", b"")
+
+        self.sp.info()
+        called_command = mock_subprocess.call_args[0][0]
+
+        # Check if the constructed command is correct
+        expected_command_part = "tw --url http://tower-api.com --insecure info"
+        self.assertIn(expected_command_part, called_command)
+
+        # Check if the cli_args are included in the called command
+        for arg in self.cli_args:
+            self.assertIn(arg, called_command)
+
+    @patch("subprocess.Popen")
+    def test_info_command_dryrun(self, mock_subprocess):
+        # Initialize SeqeraPlatform with dryrun enabled
+        self.sp.dryrun = True
+        self.sp.info()
+
+        # Check that subprocess.Popen is not called
+        mock_subprocess.assert_not_called()
+
 
 class TestKitOptions(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #151 to use Tw CLI options with `--cli` and also `--dryrun` when invoking the `info` method.

Test with:
```
$ seqerakit --info --cli="--url=https://cloud.seqera.io/api"
```

Should return:
```console      
INFO:root: Running command: tw --url=https://cloud.seqera.io/api info
Details
    -------------------------+-----------------------------
     Tower API endpoint      | https://cloud.seqera.io/api 
     Tower API version       | 1.25.0                      
     Tower version           | 24.2.0_cycle20              
     CLI version             | 0.9.2 (39a2ec6)             
     CLI minimum API version | 1.15                        
     Authenticated user      | esha-joshi                  

    System health status
    ---------------------------------------+----
     Remote API server connection check    | OK 
     Tower API version check               | OK 
     Authentication API credential's token | OK
```
And with `--dryrun`:

```
$ seqerakit --info --cli="--url=https://cloud.seqera.io/api" --dryrun
```
```console
INFO:root:DRYRUN: Running command tw --url=https://cloud.seqera.io/api info
```