### PR TITLE
Report success and failures better in seqerakit

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -145,10 +145,15 @@ def main(args=None):
     options = parse_args(args if args is not None else sys.argv[1:])
     logging.basicConfig(level=options.log_level)
 
+    # Parse CLI arguments into a list and create a Seqera Platform instance
+    cli_args_list = options.cli_args.split() if options.cli_args else []
+    sp = seqeraplatform.SeqeraPlatform(cli_args=cli_args_list, dryrun=options.dryrun)
+
     # If the info flag is set, run 'tw info'
     if options.info:
-        sp = seqeraplatform.SeqeraPlatform()
-        print(sp.info())
+        result = sp.info()
+        if not options.dryrun:
+            print(result)
         return
 
     if not options.yaml:
@@ -160,11 +165,6 @@ def main(args=None):
             sys.exit(1)
         else:
             options.yaml = [sys.stdin]
-
-    # Parse CLI arguments into a list
-    cli_args_list = options.cli_args.split() if options.cli_args else []
-
-    sp = seqeraplatform.SeqeraPlatform(cli_args=cli_args_list, dryrun=options.dryrun)
 
     block_manager = BlockParser(
         sp,

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -143,7 +143,7 @@ class BlockParser:
 
 def main(args=None):
     options = parse_args(args if args is not None else sys.argv[1:])
-    logging.basicConfig(level=options.log_level)
+    logging.basicConfig(level=getattr(logging, options.log_level.upper()))
 
     # Parse CLI arguments into a list and create a Seqera Platform instance
     cli_args_list = options.cli_args.split() if options.cli_args else []
@@ -186,15 +186,10 @@ def main(args=None):
         cmd_args_dict = helper.parse_all_yaml(options.yaml, destroy=options.delete)
         for block, args_list in cmd_args_dict.items():
             for args in args_list:
-                try:
-                    # Run the 'tw' methods for each block
-                    block_manager.handle_block(
-                        block, args, destroy=options.delete, dryrun=options.dryrun
-                    )
-                except (ResourceExistsError, ResourceCreationError) as e:
-                    logging.error(e)
-                    sys.exit(1)
-    except ValueError as e:
+                block_manager.handle_block(
+                    block, args, destroy=options.delete, dryrun=options.dryrun
+                )
+    except (ResourceExistsError, ResourceCreationError, ValueError) as e:
         logging.error(e)
         sys.exit(1)
 

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -120,11 +120,6 @@ class SeqeraPlatform:
 
         return json.loads(stdout) if to_json else stdout
 
-    def _execute_info_command(self, *args, **kwargs):
-        # Directly execute 'tw info' command
-        command = ["info"]
-        return self._tw_run(command, *args, **kwargs, print_stdout=False)
-
     def _handle_command_errors(self, stdout):
         # Check for specific tw cli error patterns and raise custom exceptions
         if re.search(
@@ -159,7 +154,9 @@ class SeqeraPlatform:
     # Allow any 'tw' subcommand to be called as a method.
     def __getattr__(self, cmd):
         if cmd == "info":
-            return self._execute_info_command
+            return lambda *args, **kwargs: self._tw_run(
+                ["info"], *args, **kwargs, print_stdout=False
+            )
         if cmd == "-o json":
             return lambda *args, **kwargs: self._tw_run(
                 ["-o", "json"] + list(args), **kwargs

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -112,10 +112,10 @@ class SeqeraPlatform:
 
         return json.loads(stdout) if to_json else stdout
 
-    def _execute_info_command(self):
+    def _execute_info_command(self, *args, **kwargs):
         # Directly execute 'tw info' command
-        command = "tw info"
-        return self._execute_command(command)
+        command = ["info"]
+        return self._tw_run(command, *args, **kwargs)
 
     def _handle_command_errors(self, stdout):
         logging.error(stdout)

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -186,6 +186,32 @@ class TestSeqeraPlatformCLIArgs(unittest.TestCase):
             "--verbose is not supported as a CLI argument to seqerakit.",
         )
 
+    @patch("subprocess.Popen")
+    def test_info_command_construction(self, mock_subprocess):
+        # Mock the subprocess call to prevent actual execution
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        mock_subprocess.return_value.communicate.return_value = (b"", b"")
+
+        self.sp.info()
+        called_command = mock_subprocess.call_args[0][0]
+
+        # Check if the constructed command is correct
+        expected_command_part = "tw --url http://tower-api.com --insecure info"
+        self.assertIn(expected_command_part, called_command)
+
+        # Check if the cli_args are included in the called command
+        for arg in self.cli_args:
+            self.assertIn(arg, called_command)
+
+    @patch("subprocess.Popen")
+    def test_info_command_dryrun(self, mock_subprocess):
+        # Initialize SeqeraPlatform with dryrun enabled
+        self.sp.dryrun = True
+        self.sp.info()
+
+        # Check that subprocess.Popen is not called
+        mock_subprocess.assert_not_called()
+
 
 class TestKitOptions(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Re #152 to improve seqerakit reporting on errors and successes. 

With these changes, the  command invoked and subsequent stdout will be provided through logging by default, with improved error handling if the command fails.

Running the following YAML:
```yaml
launch:
  - name: "hello-world-test-seqerakit"
    pipeline: "https://github.com/nextflow-io/hello"
    workspace: "scidev/testing"
    compute-env: "seqera_aws_london_fusion_nvme"
```

Will return the following by default logging level of `INFO` upon success:
```
seqerakit example.yml       
INFO:root: Running command: tw launch --name hello-world-test-seqerakit --workspace scidev/testing --compute-env seqera_aws_london_fusion_nvme https://github.com/nextflow-io/hello
INFO:root: Command output: Workflow 3A8HdVzqtBDWST submitted at [scidev / testing] workspace.

    https://tower.nf/orgs/scidev/workspaces/testing/watch/3A8HdVzqtBDWST
```

If there is an error or the command fails:
```
 seqerakit example.yml
INFO:root: Running command: tw launch --name hello-world-test-seqerakit --workspace scidev/test --compute-env seqera_aws_london_fusion_nvme https://github.com/nextflow-io/hello
INFO:root: Command output: ERROR: Workspace 'test' at organization 'scidev' not found
ERROR:root:Resource creation failed: 'ERROR: Workspace 'test' at organization 'scidev' not found'. Check your config and try again.
```
Similarly in a Python script, without logging specified explicitly:
```
python test-logging.py 
Traceback (most recent call last):
  File "/Users/eshajoshi/Development/seqera-kit/dump/test-sp-class.py", line 12, in <module>
    sp.launch(
  File "/Users/eshajoshi/miniconda3/envs/dev/lib/python3.11/site-packages/seqerakit/seqeraplatform.py", line 44, in __call__
    return self.tw_instance._tw_run(command, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eshajoshi/miniconda3/envs/dev/lib/python3.11/site-packages/seqerakit/seqeraplatform.py", line 145, in _tw_run
    return self._execute_command(full_cmd, kwargs.get("to_json"), print_stout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eshajoshi/miniconda3/envs/dev/lib/python3.11/site-packages/seqerakit/seqeraplatform.py", line 114, in _execute_command
    self._handle_command_errors(str(stdout))
  File "/Users/eshajoshi/miniconda3/envs/dev/lib/python3.11/site-packages/seqerakit/seqeraplatform.py", line 134, in _handle_command_errors
    raise ResourceCreationError(
seqerakit.seqeraplatform.ResourceCreationError: Resource creation failed: 'ERROR: Workspace 'test' at organization 'scidev' not found'. Check your config and try again.
```

TODO:

- Figure out how to avoid returning stdout for methods called by the `Overwrite` class that will invoke commands to return JSON and perform searches for entities
- Add tests