### PR TITLE
Add targets flag to specify resources for creation in input YAML

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -80,6 +80,13 @@ def parse_args(args=None):
         help="Additional Seqera Platform CLI specific options to be passed,"
         " enclosed in double quotes (e.g. '--cli=\"--insecure\"').",
     )
+    yaml_processing.add_argument(
+        "--targets",
+        dest="targets",
+        type=str,
+        help="Specify the resources to be targeted for creation in a YAML file through "
+        "a comma-separated list (e.g. '--targets=teams,participants').",
+    )
     return parser.parse_args(args)
 
 
@@ -183,7 +190,9 @@ def main(args=None):
     # Parse the YAML file(s) by blocks
     # and get a dictionary of command line arguments
     try:
-        cmd_args_dict = helper.parse_all_yaml(options.yaml, destroy=options.delete)
+        cmd_args_dict = helper.parse_all_yaml(
+            options.yaml, destroy=options.delete, targets=options.targets
+        )
         for block, args_list in cmd_args_dict.items():
             for args in args_list:
                 block_manager.handle_block(

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -55,7 +55,7 @@ def parse_yaml_block(yaml_data, block_name):
     return block_name, cmd_args_list
 
 
-def parse_all_yaml(file_paths, destroy=False):
+def parse_all_yaml(file_paths, destroy=False, targets=None):
     # If multiple yamls, merge them into one dictionary
     merged_data = {}
 
@@ -107,6 +107,11 @@ def parse_all_yaml(file_paths, destroy=False):
             sys.exit(1)
 
     block_names = list(merged_data.keys())
+
+    # Filter blocks based on targets if provided
+    if targets:
+        target_blocks = set(targets.split(","))
+        block_names = [block for block in block_names if block in target_blocks]
 
     # Define the order in which the resources should be created.
     resource_order = [


### PR DESCRIPTION
Adds a new flag, `--targets`, to the CLI interface to specify "targets" for creation in an omnibus YAML file with one or more resources defined. For example, with a YAML as such:

```yaml
workspaces:
  - name: 'showcase'
    organization: 'seqerakit_automation'
    full-name: 'e2e_demo_showcase'
    overwrite: True
labels:
    - name: 'seqerakit'
      value: 'seqerakit'
      workspace: 'scidev/testing'
      overwrite: True
pipelines:
  - name: "hello-world-test-seqerakit"
    url: "https://github.com/nextflow-io/hello"
    workspace: "scidev/test"
    compute-env: "seqera_aws_london_fusion_nvme"
    revision: "master"
    overwrite: True
```    

We can specify resources to create with:
```
$ seqerakit example.yml --targets pipelines

seqerakit example.yml --targets pipelines
INFO:root: Running command: tw -o json pipelines list -w scidev/testing
INFO:root: Checking if name hello-world-test-seqerakit exists in Seqera Platform...
INFO:root: Running command: tw pipelines add --name hello-world-test-seqerakit --workspace scidev/testing --compute-env seqera_aws_london_fusion_nvme --revision master https://github.com/nextflow-io/hello
INFO:root: Command output: New pipeline 'hello-world-test-seqerakit' added at [scidev / testing] workspace
```

Resources not specified or targeted for creation like `organizations` or `workspaces` will not be included. It also enforces ordering as expected:
```
seqerakit example.yml --targets pipelines,workspaces
INFO:root: Running command: tw -o json workspaces list -o seqerakit_automation
INFO:root: Checking if workspaceName showcase exists in Seqera Platform...
INFO:root: Running command: tw workspaces add --name showcase --organization seqerakit_automation --full-name e2e_demo_showcase
...
```      