### PR TITLE
fix: handling for overwrite class without json output

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -111,7 +111,9 @@ class BlockParser:
         self.sp = sp
         self.list_for_add_method = list_for_add_method
 
-        # Create a separate instance of the Overwrite class without JSON output
+        # Create a separate instance of the Seqera Platform client without JSON output
+        # This is needed because when checking if resources exist during overwrite operations,
+        # we don't want JSON output mixed with the actual resource creation output
         sp_without_json = seqeraplatform.SeqeraPlatform(
             cli_args=sp.cli_args,
             dryrun=sp.dryrun,

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -110,8 +110,14 @@ class BlockParser:
         """
         self.sp = sp
         self.list_for_add_method = list_for_add_method
-        # Create an instance of Overwrite class
-        self.overwrite_method = overwrite.Overwrite(self.sp)
+
+        # Create a separate instance of the Overwrite class without JSON output
+        sp_without_json = seqeraplatform.SeqeraPlatform(
+            cli_args=sp.cli_args,
+            dryrun=sp.dryrun,
+            json=False,
+        )
+        self.overwrite_method = overwrite.Overwrite(sp_without_json)
 
     def handle_block(self, block, args, destroy=False, dryrun=False):
         # Check if delete is set to True, and call delete handler

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -139,10 +139,12 @@ class SeqeraPlatform:
 
         if self.json or to_json:
             out = json.loads(stdout)
-            print(json.dumps(out))
+            if should_print:
+                print(json.dumps(out))
         else:
             out = stdout
-            print(stdout)
+            if should_print:
+                print(stdout)
 
         return out
 


### PR DESCRIPTION
Fixes #170. 

- Creates a separate instance of the `SeqeraPlatform` class for `Overwrite` to inherit without using the JSON option so we don't double up on `-o json`. The `Overwrite` class handles emitting output to JSON natively so we don't need this handling. 
- Modified `_execute_command` to respect `print_stdout` setting when JSON output is enabled. Previously, stdout would always be printed when processing JSON output, regardless of the `print_stdout` flag. This change ensures consistent behavior between JSON and non-JSON output modes.