### PR TITLE
FIx handling of resource creation error when emitting JSON output

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -110,8 +110,14 @@ class BlockParser:
         """
         self.sp = sp
         self.list_for_add_method = list_for_add_method
-        # Create an instance of Overwrite class
-        self.overwrite_method = overwrite.Overwrite(self.sp)
+
+        # Create a separate instance of the Overwrite class without JSON output
+        sp_without_json = seqeraplatform.SeqeraPlatform(
+            cli_args=sp.cli_args,
+            dryrun=sp.dryrun,
+            json=False,
+        )
+        self.overwrite_method = overwrite.Overwrite(sp_without_json)
 
     def handle_block(self, block, args, destroy=False, dryrun=False):
         # Check if delete is set to True, and call delete handler

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -139,10 +139,12 @@ class SeqeraPlatform:
 
         if self.json or to_json:
             out = json.loads(stdout)
-            print(json.dumps(out))
+            if should_print:
+                print(json.dumps(out))
         else:
             out = stdout
-            print(stdout)
+            if should_print:
+                print(stdout)
 
         return out
 

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -134,19 +134,22 @@ class SeqeraPlatform:
         if should_print and not self.json:
             logging.info(f" Command output: {stdout}")
 
-        if "ERROR: " in stdout or process.returncode != 0:
+        # Try JSON parsing first
+        if self.json or to_json:
+            try:
+                out = json.loads(stdout)
+                if should_print:
+                    print(json.dumps(out))
+                return out
+            except json.JSONDecodeError:
+                pass
+
+        if process.returncode != 0 and "ERROR: " in stdout:
             self._handle_command_errors(stdout)
 
-        if self.json or to_json:
-            out = json.loads(stdout)
-            if should_print:
-                print(json.dumps(out))
-        else:
-            out = stdout
-            if should_print:
-                print(stdout)
-
-        return out
+        if should_print:
+            print(stdout)
+        return stdout
 
     def _handle_command_errors(self, stdout):
         # Check for specific tw cli error patterns and raise custom exceptions

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 from seqerakit import seqeraplatform
+from seqerakit.seqeraplatform import ResourceCreationError, ResourceExistsError
 import json
 import subprocess
 import os
@@ -382,11 +383,9 @@ class TestSeqeraPlatformOutputHandling(unittest.TestCase):
         log_output = self.log_capture.getvalue()
         self.assertIn("Command output: output", log_output)
 
-        # Clear the log capture
         self.log_capture.truncate(0)
         self.log_capture.seek(0)
 
-        # Test with print_stdout=False
         self.sp._execute_command("tw pipelines list", print_stdout=False)
         log_output = self.log_capture.getvalue()
         self.assertNotIn("Command output: output", log_output)
@@ -408,9 +407,50 @@ class TestSeqeraPlatformOutputHandling(unittest.TestCase):
         mock_subprocess.return_value = MagicMock(returncode=0)
         mock_subprocess.return_value.communicate.return_value = (b"Invalid JSON", b"")
 
-        with self.assertRaises(json.JSONDecodeError):
-            self.sp._execute_command("tw pipelines list", to_json=True)
+        result = self.sp._execute_command("tw pipelines list", to_json=True)
 
+        self.assertEqual(result, "Invalid JSON")  # Should return raw stdout
+        mock_subprocess.assert_called_once_with(
+            "tw pipelines list",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=True
+        )
+
+    @patch("subprocess.Popen")
+    def test_json_parsing_failure_fallback(self, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        mock_subprocess.return_value.communicate.return_value = (b"Invalid JSON", b"")
+        
+        result = self.sp._execute_command("tw pipelines list", to_json=True)
+        
+        self.assertEqual(result, "Invalid JSON")
+
+    @patch("subprocess.Popen")
+    def test_error_with_nonzero_return_code(self, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=1)
+        mock_subprocess.return_value.communicate.return_value = (b"ERROR: Something went wrong", b"")
+        
+        with self.assertRaises(ResourceCreationError):
+            self.sp._execute_command("tw pipelines list")
+
+    @patch("subprocess.Popen")
+    def test_correct_logging(self, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        mock_subprocess.return_value.communicate.return_value = (b"Command output", b"")
+        
+        with patch('logging.info') as mock_logging:
+            # Test with JSON enabled
+            self.sp.json = True
+            self.sp._execute_command("tw pipelines list")
+            mock_logging.assert_called_once_with(" Running command: tw pipelines list")
+            
+            mock_logging.reset_mock()
+            
+            # Test with JSON disabled
+            self.sp.json = False
+            self.sp._execute_command("tw pipelines list")
+            mock_logging.assert_any_call(" Command output: Command output")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #166 to improve command output handling and JSON parsing. Modified `_execute_command` to attempt JSON parsing first before falling back to standard output handling.

Changes:
- Attempt JSON parsing before error checking
- Properly respect `print_stdout` flag for both JSON and standard output
- Add more  test coverage for JSON parsing, output suppression, and error handling