### PR TITLE
Draft: add support for a variables file as input for templating

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -90,6 +90,12 @@ def parse_args(args=None):
         help="Specify the resources to be targeted for creation in a YAML file through "
         "a comma-separated list (e.g. '--targets=teams,participants').",
     )
+    yaml_processing.add_argument(
+        "--env-file",
+        dest="env_file",
+        type=str,
+        help="Path to a YAML file containing environment variables for configuration.",
+    )
     return parser.parse_args(args)
 
 
@@ -165,7 +171,10 @@ def main(args=None):
     cli_args_list = options.cli_args.split() if options.cli_args else []
 
     sp = seqeraplatform.SeqeraPlatform(
-        cli_args=cli_args_list, dryrun=options.dryrun, json=options.json
+        cli_args=cli_args_list,
+        dryrun=options.dryrun,
+        json=options.json,
+        env_file=options.env_file,
     )
 
     # If the info flag is set, run 'tw info'

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -19,6 +19,7 @@ import logging
 import subprocess
 import re
 import json
+import yaml
 
 
 class SeqeraPlatform:
@@ -43,7 +44,9 @@ class SeqeraPlatform:
             return self.tw_instance._tw_run(command, **kwargs)
 
     # Constructs a new SeqeraPlatform instance
-    def __init__(self, cli_args=None, dryrun=False, print_stdout=True, json=False):
+    def __init__(
+        self, cli_args=None, dryrun=False, print_stdout=True, json=False, env_file=None
+    ):
         if cli_args and "--verbose" in cli_args:
             raise ValueError(
                 "--verbose is not supported as a CLI argument to seqerakit."
@@ -53,6 +56,9 @@ class SeqeraPlatform:
         self.print_stdout = print_stdout
         self.json = json
         self._suppress_output = False
+        self.variables = {}
+        if env_file:
+            self.load_variables_file(env_file)
 
     def _construct_command(self, cmd, *args, **kwargs):
         command = ["tw"] + self.cli_args
@@ -81,6 +87,11 @@ class SeqeraPlatform:
                     f"Empty string argument found for parameter '{current_arg}'. "
                     "Please provide a valid value or remove the argument."
                 )
+
+    def load_variables_file(self, file_path):
+        # Load variables from a YAML file then merge with those in the env
+        with open(file_path, "r") as file:
+            self.variables = {**os.environ, **yaml.safe_load(file)}
 
     # Checks environment variables to see that they are set accordingly
     def _check_env_vars(self, command):
@@ -118,11 +129,14 @@ class SeqeraPlatform:
                     for env_var in re.findall(pattern, arg):
                         var_name = extractor(env_var)
 
-                        # Check variable exists
-                        if var_name not in os.environ:
+                        if var_name not in self.variables:
                             raise EnvironmentError(
-                                f"Environment variable {env_var} not found!"
+                                f"Variable {env_var} not found in the environment"
+                                " or the variables file!"
                             )
+                        processed_arg = processed_arg.replace(
+                            env_var, str(self.variables[var_name])
+                        )
 
                 full_cmd_parts.append(processed_arg)
                 continue


### PR DESCRIPTION
- POC to test out support for an input file with variables defined and used for templating
- Modified `_check_env_vars()` to use a unified variables dictionary
- Variables from the YAML file will override environment variables if there are conflicts

## Testing
With an example vars file called `vars.yaml`:
```yaml
EXECUTOR: gcp
COMPUTE_ENV_NAME: tower_cloud_testing_finland_fusionv2
ORGANIZATION_NAME: scidev
WORKSPACE_NAME: gcp
PIPELINE_PROFILE: test
```

And an `example.yaml` YAML using the variables:
```yaml
pipelines:
  - name: "nf-core-rnaseq-$EXECUTOR"
    url: "https://github.com/nf-core/rnaseq"
    description: "RNA sequencing analysis pipeline using STAR, RSEM, HISAT2 or Salmon with gene/isoform counts and extensive quality control."
    workspace: "$ORGANIZATION_NAME/$WORKSPACE_NAME"
    compute-env: "$COMPUTE_ENV_NAME"
    revision: "3.14.0"
    profile: "$PIPELINE_PROFILE"
    labels: "template,star_salmon,yeast"
    params:
      outdir: "s3://scidev-eu-west-1/staging/nf-core-rnaseq/results"
      igenomes_base: "s3://igenomes-eu-west-2/references/"
    overwrite: False
 ```
 
 Run with:
 ```bash
 seqerakit example.yaml --dryrun --env-file vars.yaml
 
 INFO:root:DRYRUN: Running command tw pipelines add --name nf-core-rnaseq-gcp --description 'RNA sequencing analysis pipeline using STAR, RSEM, HISAT2 or Salmon with gene/isoform counts and extensive quality control.' --workspace scidev/gcp --compute-env tower_cloud_testing_finland_fusionv2 --revision 3.14.0 --profile test --labels template,star_salmon,yeast https://github.com/nf-core/rnaseq --params-file /var/folders/f5/l1wj3_814_9g_s_37b0_950c0000gn/T/tmpnhrtc4_r.yaml
 ```
