### PR TITLE
Use params file for environment variables

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -90,6 +90,12 @@ def parse_args(args=None):
         help="Specify the resources to be targeted for creation in a YAML file through "
         "a comma-separated list (e.g. '--targets=teams,participants').",
     )
+    yaml_processing.add_argument(
+        "--env-file",
+        dest="env_file",
+        type=str,
+        help="Path to a YAML file containing environment variables for configuration.",
+    )
     return parser.parse_args(args)
 
 
@@ -165,7 +171,10 @@ def main(args=None):
     cli_args_list = options.cli_args.split() if options.cli_args else []
 
     sp = seqeraplatform.SeqeraPlatform(
-        cli_args=cli_args_list, dryrun=options.dryrun, json=options.json
+        cli_args=cli_args_list,
+        dryrun=options.dryrun,
+        json=options.json,
+        env_file=options.env_file,
     )
 
     # If the info flag is set, run 'tw info'

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -179,10 +179,7 @@ def main(args=None):
             os.environ.update(env_vars)
 
     sp = seqeraplatform.SeqeraPlatform(
-        cli_args=cli_args_list,
-        dryrun=options.dryrun,
-        json=options.json,
-        env_file=options.env_file,
+        cli_args=cli_args_list, dryrun=options.dryrun, json=options.json
     )
 
     # If the info flag is set, run 'tw info'

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -20,6 +20,8 @@ the required options for each resource based on the Seqera Platform CLI.
 import argparse
 import logging
 import sys
+import os
+import yaml
 
 from seqerakit import seqeraplatform, helper, overwrite
 from seqerakit.seqeraplatform import ResourceExistsError, ResourceCreationError
@@ -169,6 +171,12 @@ def main(args=None):
 
     # Parse CLI arguments into a list
     cli_args_list = options.cli_args.split() if options.cli_args else []
+
+    # add and overwrite existing environment variables with those in the env_file
+    if options.env_file:
+        with open(options.env_file, "r") as f:
+            env_vars = yaml.safe_load(f)
+            os.environ.update(env_vars)
 
     sp = seqeraplatform.SeqeraPlatform(
         cli_args=cli_args_list,

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -19,6 +19,7 @@ import logging
 import subprocess
 import re
 import json
+import yaml
 
 
 class SeqeraPlatform:
@@ -43,7 +44,9 @@ class SeqeraPlatform:
             return self.tw_instance._tw_run(command, **kwargs)
 
     # Constructs a new SeqeraPlatform instance
-    def __init__(self, cli_args=None, dryrun=False, print_stdout=True, json=False):
+    def __init__(
+        self, cli_args=None, dryrun=False, print_stdout=True, json=False, env_file=None
+    ):
         if cli_args and "--verbose" in cli_args:
             raise ValueError(
                 "--verbose is not supported as a CLI argument to seqerakit."
@@ -53,6 +56,9 @@ class SeqeraPlatform:
         self.print_stdout = print_stdout
         self.json = json
         self._suppress_output = False
+        self.variables = {}
+        if env_file:
+            self.load_variables_file(env_file)
 
     def _construct_command(self, cmd, *args, **kwargs):
         command = ["tw"] + self.cli_args
@@ -81,6 +87,11 @@ class SeqeraPlatform:
                     f"Empty string argument found for parameter '{current_arg}'. "
                     "Please provide a valid value or remove the argument."
                 )
+
+    def load_variables_file(self, file_path):
+        # Load variables from a YAML file then merge with those in the env
+        with open(file_path, "r") as file:
+            self.variables = {**os.environ, **yaml.safe_load(file)}
 
     # Checks environment variables to see that they are set accordingly
     def _check_env_vars(self, command):
@@ -118,11 +129,14 @@ class SeqeraPlatform:
                     for env_var in re.findall(pattern, arg):
                         var_name = extractor(env_var)
 
-                        # Check variable exists
-                        if var_name not in os.environ:
+                        if var_name not in self.variables:
                             raise EnvironmentError(
-                                f"Environment variable {env_var} not found!"
+                                f"Variable {env_var} not found in the environment"
+                                " or the variables file!"
                             )
+                        processed_arg = processed_arg.replace(
+                            env_var, str(self.variables[var_name])
+                        )
 
                 full_cmd_parts.append(processed_arg)
                 continue


### PR DESCRIPTION
Alternative to #181 

Instead of parsing the env file in the class, it loads it into the environment.

The advantage is it's more broadly applicable (i.e. it works everywhere, the disadvantage is it's pretty blunt and just wipes out any existing environment variables.

Currently the `--env-file` takes precedence over the existing environment variables but this could be swapped.