### PR TITLE
fix: Correctly catches and raises errors from tw cli

### DIFF
--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -158,7 +158,7 @@ class SeqeraPlatform:
             except json.JSONDecodeError:
                 pass
 
-        if process.returncode != 0 and "ERROR: " in stdout:
+        if process.returncode != 0 and "ERROR:" in stdout:
             self._handle_command_errors(stdout)
 
         if should_print:


### PR DESCRIPTION
Errors were being ignored in the tw cli output because it was checking for `"ERROR: "` but the error message is actually `"ERROR:"` with additional ANSI escape codes. This PR removes the space which correctly catches the error.

fixes #178 
