### PR TITLE
fix: catch and handle all non-zero exit codes

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -26,7 +26,11 @@ import yaml
 from pathlib import Path
 
 from seqerakit import seqeraplatform, helper, overwrite
-from seqerakit.seqeraplatform import ResourceExistsError, ResourceCreationError
+from seqerakit.seqeraplatform import (
+    ResourceExistsError,
+    ResourceNotFoundError,
+    CommandError,
+)
 from seqerakit import __version__
 
 logger = logging.getLogger(__name__)
@@ -270,7 +274,7 @@ def main(args=None):
                 block_manager.handle_block(
                     block, args, destroy=options.delete, dryrun=options.dryrun
                 )
-    except (ResourceExistsError, ResourceCreationError, ValueError) as e:
+    except (ResourceExistsError, ResourceNotFoundError, CommandError, ValueError) as e:
         logging.error(e)
         sys.exit(1)
 

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -158,7 +158,7 @@ class SeqeraPlatform:
             except json.JSONDecodeError:
                 pass
 
-        if process.returncode != 0 and "ERROR:" in stdout:
+        if process.returncode != 0:
             self._handle_command_errors(stdout)
 
         if should_print:
@@ -173,10 +173,11 @@ class SeqeraPlatform:
             raise ResourceExistsError(
                 "Resource already exists. Please delete first or set 'overwrite: true'"
             )
+        elif re.search(r"ERROR: .*not found", stdout, flags=re.IGNORECASE):
+            raise ResourceNotFoundError(f"Resource not found: '{stdout}'")
         else:
             raise ResourceCreationError(
-                f"Resource creation failed: '{stdout}'. "
-                "Check your config and try again."
+                f"Command failed: '{stdout}'. " "Check your input and try again."
             )
 
     def _tw_run(self, cmd, *args, **kwargs):
@@ -214,4 +215,8 @@ class ResourceExistsError(Exception):
 
 
 class ResourceCreationError(Exception):
+    pass
+
+
+class ResourceNotFoundError(Exception):
     pass

--- a/seqerakit/seqeraplatform.py
+++ b/seqerakit/seqeraplatform.py
@@ -176,8 +176,8 @@ class SeqeraPlatform:
         elif re.search(r"ERROR: .*not found", stdout, flags=re.IGNORECASE):
             raise ResourceNotFoundError(f"Resource not found: '{stdout}'")
         else:
-            raise ResourceCreationError(
-                f"Command failed: '{stdout}'. " "Check your input and try again."
+            raise CommandError(
+                f"Command failed: '{stdout}'. Check your input and try again."
             )
 
     def _tw_run(self, cmd, *args, **kwargs):
@@ -210,11 +210,11 @@ class SeqeraPlatform:
         return self.TwCommand(self, cmd.replace("_", "-"))
 
 
-class ResourceExistsError(Exception):
+class CommandError(Exception):
     pass
 
 
-class ResourceCreationError(Exception):
+class ResourceExistsError(Exception):
     pass
 
 

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 from seqerakit import seqeraplatform
-from seqerakit.seqeraplatform import ResourceCreationError
+from seqerakit.seqeraplatform import CommandError
 import json
 import subprocess
 import os
@@ -91,7 +91,7 @@ class TestSeqeraPlatform(unittest.TestCase):
             command = getattr(self.sp, "pipelines")
 
             # Check that the error is raised
-            with self.assertRaises(seqeraplatform.ResourceCreationError):
+            with self.assertRaises(seqeraplatform.CommandError):
                 command("import", "my_pipeline.json", "--name", "pipeline_name")
 
     def test_empty_string_argument(self):
@@ -422,7 +422,7 @@ class TestSeqeraPlatformOutputHandling(unittest.TestCase):
             b"",
         )
 
-        with self.assertRaises(seqeraplatform.ResourceCreationError):
+        with self.assertRaises(seqeraplatform.CommandError):
             with self.sp.suppress_output():
                 self.sp._execute_command("tw pipelines list")
 
@@ -458,7 +458,7 @@ class TestSeqeraPlatformOutputHandling(unittest.TestCase):
             b"",
         )
 
-        with self.assertRaises(ResourceCreationError):
+        with self.assertRaises(CommandError):
             self.sp._execute_command("tw pipelines list")
 
     @patch("subprocess.Popen")


### PR DESCRIPTION
Re #194, I am not sure/I don't remember why we would check for specific strings in the first place but this generic approach allows us to catch all error cases. 