### PR TITLE
add `on_exists` param with behaviour `fail`, `ignore` and `overwrite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,14 +301,34 @@ params:
 
 **Note**: If duplicate parameters are provided, the parameters provided as key-value pairs inside the `params` nested dictionary of the YAML file will take precedence **over** values in the provided `params-file`.
 
-### 2. `overwrite` Functionality
+### 2. `on_exists` Functionality
 
-For every entity defined in your YAML file, you can specify `overwrite: True` to overwrite any existing entities in Seqera Platform of the same name.
+For every entity defined in your YAML file, you can specify how to handle cases where the entity already exists using the `on_exists` parameter with one of three options:
 
-`seqerakit` will first check to see if the name of the entity exists, if so, it will invoke a `tw <subcommand> delete` command before attempting to create it based on the options defined in the YAML file.
+- `fail` (default): Raise an error if the entity already exists
+- `ignore`: Skip creation if the entity already exists
+- `overwrite`: Delete the existing entity and create a new one based on the YAML configuration
+
+Example usage in YAML:
+
+```yaml
+workspaces:
+  - name: 'showcase'
+    organization: 'seqerakit_automation'
+    on_exists: 'overwrite'  # Will delete and recreate if exists
+```
+
+```yaml
+credentials:
+  - name: 'github_credentials'
+    workspace: 'seqerakit_automation/showcase'
+    on_exists: 'ignore'  # Will skip if already exists
+```
+
+When using the `overwrite` option, `seqerakit` will first check if the entity exists, and if so, it will invoke a `tw <subcommand> delete` command before attempting to create it based on the options defined in the YAML file:
 
 ```console
-DEBUG:root: Overwrite is set to 'True' for organizations
+DEBUG:root: on_exists is set to 'overwrite' for organizations
 
 DEBUG:root: Running command: tw -o json organizations list
 DEBUG:root: The attempted organizations resource already exists. Overwriting.
@@ -316,6 +336,8 @@ DEBUG:root: The attempted organizations resource already exists. Overwriting.
 DEBUG:root: Running command: tw organizations delete --name $SEQERA_ORGANIZATION_NAME
 DEBUG:root: Running command: tw organizations add --name $SEQERA_ORGANIZATION_NAME --full-name $SEQERA_ORGANIZATION_NAME --description 'Example of an organization'
 ```
+
+> **Note**: For backward compatibility, the `overwrite: True|False` parameter is still supported but deprecated. It will be mapped to `on_exists: 'overwrite'|'fail'` respectively.
 
 ### 3. Specifying JSON configuration files with `file-path`
 

--- a/examples/yaml/e2e/actions.yml
+++ b/examples/yaml/e2e/actions.yml
@@ -5,7 +5,7 @@ actions:
     workspace: 'seqerakit-e2e/showcase'
     compute-env: 'seqera_aws_virginia_fusionv2_nvme'
     work-dir: 's3://scidev-testing'
-    revision: 'main'
+    revision: 'master'
     profile: 'test'
     params:
       outdir: s3://seqeralabs-showcase/nf-core-rnaseq/action/'

--- a/examples/yaml/e2e/actions.yml
+++ b/examples/yaml/e2e/actions.yml
@@ -9,4 +9,4 @@ actions:
     profile: 'test'
     params:
       outdir: s3://seqeralabs-showcase/nf-core-rnaseq/action/'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/actions.yml
+++ b/examples/yaml/e2e/actions.yml
@@ -5,7 +5,7 @@ actions:
     workspace: 'seqerakit-e2e/showcase'
     compute-env: 'seqera_aws_virginia_fusionv2_nvme'
     work-dir: 's3://scidev-testing'
-    revision: 'master'
+    revision: 'main'
     profile: 'test'
     params:
       outdir: s3://seqeralabs-showcase/nf-core-rnaseq/action/'

--- a/examples/yaml/e2e/compute-envs.yml
+++ b/examples/yaml/e2e/compute-envs.yml
@@ -14,16 +14,16 @@ compute-envs:
     no-ebs-auto-scale: True
     max-cpus: 500
     wait: AVAILABLE
-    overwrite: True
+    on_exists: overwrite
   - name: 'seqera_azure_virginia'
     workspace: 'seqerakit-e2e/showcase'
     credentials: 'azure_credentials'
     wait: 'AVAILABLE'
     file-path: './examples/yaml/compute-envs/seqera_azure_virginia.json'
-    overwrite: True
+    on_exists: overwrite
   - name: 'seqera_gcp_finland'
     workspace: 'seqerakit-e2e/showcase'
     credentials: 'google_credentials'
     wait: 'AVAILABLE'
     file-path: './examples/yaml/compute-envs/seqera_gcp_finland.json'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/credentials.yml
+++ b/examples/yaml/e2e/credentials.yml
@@ -4,21 +4,21 @@ credentials:
     workspace: 'seqerakit-e2e/showcase'
     username: 'ejseqera'
     password: '$TOWER_GITHUB_PASSWORD'
-    overwrite: True
+    on_exists: overwrite
   - type: 'container-reg'
     name: 'dockerhub_credentials'
     workspace: 'seqerakit-e2e/showcase'
     username: 'eshajoshi'
     password: '$DOCKERHUB_PASSWORD'
     registry: 'docker.io'
-    overwrite: True
+    on_exists: overwrite
   - type: 'aws'
     name: 'aws_credentials'
     workspace: 'seqerakit-e2e/showcase'
     access-key: '$AWS_ACCESS_KEY_ID'
     secret-key: '$AWS_SECRET_ACCESS_KEY'
     assume-role-arn: '$AWS_ASSUME_ROLE_ARN'
-    overwrite: True
+    on_exists: overwrite
   - type: 'azure'
     name: 'azure_credentials'
     workspace: 'seqerakit-e2e/showcase'
@@ -26,9 +26,9 @@ credentials:
     batch-name: 'seqeralabs'
     storage-key: '$AZURE_STORAGE_KEY'
     storage-name: 'seqeralabs'
-    overwrite: True
+    on_exists: overwrite
   - type: 'google'
     name: 'google_credentials'
     workspace: 'seqerakit-e2e/showcase'
     key: '$GOOGLE_KEY'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/datasets.yml
+++ b/examples/yaml/e2e/datasets.yml
@@ -4,28 +4,28 @@ datasets:
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/rnaseq_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'sarek_samples'
     description: 'Samplesheet to run the nf-core/sarek pipeline from end-to-end'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/sarek_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'viralrecon_illumina_samples'
     description: 'Samplesheet to run the nf-core/viralrecon pipeline from end-to-end with Illumina data'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/viralrecon_illumina_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'viralrecon_nanopore_samples'
     description: 'Samplesheet to run the nf-core/viralrecon pipeline from end-to-end with Nanopore data'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/viralrecon_nanopore_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'sentieon_samples'
     description: 'Samplesheet to run the seqeralabs/nf-sentieon pipeline from end-to-end'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/sentieon_samples.csv'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/labels.yml
+++ b/examples/yaml/e2e/labels.yml
@@ -2,4 +2,4 @@ labels:
   - name: 'seqerakit'
     value: 'test'
     workspace: 'seqerakit-e2e/showcase'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/members.yml
+++ b/examples/yaml/e2e/members.yml
@@ -1,4 +1,4 @@
 members:
    - user: 'laramie.lindsey+owner@seqera.io'
      organization: 'seqerakit-e2e'
-     overwrite: False
+     on_exists: ignore

--- a/examples/yaml/e2e/organizations.yml
+++ b/examples/yaml/e2e/organizations.yml
@@ -4,4 +4,4 @@ organizations:
     description: 'Organization created E2E with seqerakit CLI scripting'
     location: 'Global'
     website: 'https://seqera.io/'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/participants.yml
+++ b/examples/yaml/e2e/participants.yml
@@ -3,9 +3,9 @@ participants:
     type: 'TEAM'
     workspace: 'seqerakit-e2e/showcase'
     role: 'ADMIN'
-    overwrite: True
+    on_exists: overwrite
   - name: 'adam.talbot@seqera.io'
     type: 'MEMBER'
     workspace: 'seqerakit-e2e/showcase'
     role: 'LAUNCH'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/pipelines.yml
+++ b/examples/yaml/e2e/pipelines.yml
@@ -11,12 +11,12 @@ pipelines:
       outdir: 's3://seqeralabs-showcase/nf-core-rnaseq/results'
     config: './examples/yaml/pipelines/nextflow.config'
     pre-run: './examples/yaml/pipelines/pre_run.txt'
-    overwrite: True
+    on_exists: overwrite
   - name: 'nf-core-sarek'
     workspace: 'seqerakit-e2e/showcase'
     compute-env: 'seqera_azure_virginia'
     file-path: './examples/yaml/pipelines/nf-core-sarek_pipeline.json'
-    overwrite: True
+    on_exists: overwrite
   - name: 'nf-core-viralrecon-illumina'
     url: 'https://github.com/nf-core/viralrecon'
     workspace: 'seqerakit-e2e/showcase'
@@ -28,9 +28,9 @@ pipelines:
     params-file: './examples/yaml/pipelines/nf_core_viralrecon_illumina_params.yml'
     config: './examples/yaml/pipelines/nextflow.config'
     pre-run: './examples/yaml/pipelines/pre_run.txt'
-    overwrite: True
+    on_exists: overwrite
   - name: 'nf-sentieon'
     workspace: 'seqerakit-e2e/showcase'
     compute-env: 'seqera_aws_virginia_fusionv2_nvme'
     file-path: './examples/yaml/pipelines/nf_sentieon_pipeline.json'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/secrets.yml
+++ b/examples/yaml/e2e/secrets.yml
@@ -2,4 +2,4 @@ secrets:
   - name: 'SENTIEON_LICENSE_BASE64'
     workspace: 'seqerakit-e2e/showcase'
     value: '$SENTIEON_LICENSE_BASE64'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/teams.yml
+++ b/examples/yaml/e2e/teams.yml
@@ -6,4 +6,4 @@ teams:
       - 'esha.joshi@seqera.io'
       - 'adam.talbot@seqera.io'
       - 'drpatelhh@gmail.com'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/e2e/workspaces.yml
+++ b/examples/yaml/e2e/workspaces.yml
@@ -4,4 +4,4 @@ workspaces:
     organization: 'seqerakit-e2e'
     description: 'Workspace created E2E with seqerakit CLI scripting'
     visibility: 'PRIVATE'
-    overwrite: True
+    on_exists: overwrite

--- a/examples/yaml/seqerakit-e2e.yml
+++ b/examples/yaml/seqerakit-e2e.yml
@@ -4,7 +4,7 @@ organizations:
     description: 'Organization created E2E with seqerakit CLI scripting'
     location: 'Global'
     website: 'https://seqera.io/'
-    overwrite: True
+    on_exists: overwrite
 teams:
   - name: 'scidev_team'
     organization: 'seqerakit-e2e'
@@ -13,46 +13,46 @@ teams:
       - 'esha.joshi@seqera.io'
       - 'adam.talbot@seqera.io'
       - 'drpatelhh@gmail.com'
-    overwrite: True
+    on_exists: overwrite
 workspaces:
   - name: 'showcase'
     full-name: 'showcase'
     organization: 'seqerakit-e2e'
     description: 'Workspace created E2E with seqerakit CLI scripting'
     visibility: 'PRIVATE'
-    overwrite: True
+    on_exists: overwrite
 participants:
   - name: 'scidev_team'
     type: 'TEAM'
     workspace: 'seqerakit-e2e/showcase'
     role: 'ADMIN'
-    overwrite: True
+    on_exists: overwrite
   - name: 'adam.talbot@seqera.io'
     type: 'MEMBER'
     workspace: 'seqerakit-e2e/showcase'
     role: 'LAUNCH'
-    overwrite: True
+    on_exists: overwrite
 credentials:
   - type: 'github'
     name: 'github_credentials'
     workspace: 'seqerakit-e2e/showcase'
     username: 'ejseqera'
     password: '$TOWER_GITHUB_PASSWORD'
-    overwrite: True
+    on_exists: overwrite
   - type: 'container-reg'
     name: 'dockerhub_credentials'
     workspace: 'seqerakit-e2e/showcase'
     username: 'eshajoshi'
     password: '$DOCKERHUB_PASSWORD'
     registry: 'docker.io'
-    overwrite: True
+    on_exists: overwrite
   - type: 'aws'
     name: 'aws_credentials'
     workspace: 'seqerakit-e2e/showcase'
     access-key: '$AWS_ACCESS_KEY_ID'
     secret-key: '$AWS_SECRET_ACCESS_KEY'
     assume-role-arn: '$AWS_ASSUME_ROLE_ARN'
-    overwrite: True
+    on_exists: overwrite
   - type: 'azure'
     name: 'azure_credentials'
     workspace: 'seqerakit-e2e/showcase'
@@ -60,17 +60,17 @@ credentials:
     batch-name: 'seqeralabs'
     storage-key: '$AZURE_STORAGE_KEY'
     storage-name: 'seqeralabs'
-    overwrite: True
+    on_exists: overwrite
   - type: 'google'
     name: 'google_credentials'
     workspace: 'seqerakit-e2e/showcase'
     key: '$GOOGLE_KEY'
-    overwrite: True
+    on_exists: overwrite
 secrets:
   - name: 'SENTIEON_LICENSE_BASE64'
     workspace: 'seqerakit-e2e/showcase'
     value: '$SENTIEON_LICENSE_BASE64'
-    overwrite: True
+    on_exists: overwrite
 compute-envs:
   - type: aws-batch
     config-mode: forge
@@ -87,50 +87,50 @@ compute-envs:
     no-ebs-auto-scale: True
     max-cpus: 500
     wait: AVAILABLE
-    overwrite: True
+    on_exists: overwrite
   - name: 'seqera_azure_virginia'
     workspace: 'seqerakit-e2e/showcase'
     credentials: 'azure_credentials'
     wait: 'AVAILABLE'
     file-path: './examples/yaml/compute-envs/seqera_azure_virginia.json'
-    overwrite: True
+    on_exists: overwrite
   - name: 'seqera_gcp_finland'
     workspace: 'seqerakit-e2e/showcase'
     credentials: 'google_credentials'
     wait: 'AVAILABLE'
     file-path: './examples/yaml/compute-envs/seqera_gcp_finland.json'
-    overwrite: True
+    on_exists: overwrite
 datasets:
   - name: 'rnaseq_samples'
     description: 'Samplesheet to run the nf-core/rnaseq pipeline from end-to-end'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/rnaseq_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'sarek_samples'
     description: 'Samplesheet to run the nf-core/sarek pipeline from end-to-end'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/sarek_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'viralrecon_illumina_samples'
     description: 'Samplesheet to run the nf-core/viralrecon pipeline from end-to-end with Illumina data'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/viralrecon_illumina_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'viralrecon_nanopore_samples'
     description: 'Samplesheet to run the nf-core/viralrecon pipeline from end-to-end with Nanopore data'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/viralrecon_nanopore_samples.csv'
-    overwrite: True
+    on_exists: overwrite
   - name: 'sentieon_samples'
     description: 'Samplesheet to run the seqeralabs/nf-sentieon pipeline from end-to-end'
     header: true
     workspace: 'seqerakit-e2e/showcase'
     file-path: './examples/yaml/datasets/sentieon_samples.csv'
-    overwrite: True
+    on_exists: overwrite
 pipelines:
   - name: 'nf-core-rnaseq'
     url: 'https://github.com/nf-core/rnaseq'
@@ -144,12 +144,12 @@ pipelines:
       outdir: 's3://seqeralabs-showcase/nf-core-rnaseq/results'
     config: './examples/yaml/pipelines/nextflow.config'
     pre-run: './examples/yaml/pipelines/pre_run.txt'
-    overwrite: True
+    on_exists: overwrite
   - name: 'nf-core-sarek'
     workspace: 'seqerakit-e2e/showcase'
     compute-env: 'seqera_azure_virginia'
     file-path: './examples/yaml/pipelines/nf-core-sarek_pipeline.json'
-    overwrite: True
+    on_exists: overwrite
   - name: 'nf-core-viralrecon-illumina'
     url: 'https://github.com/nf-core/viralrecon'
     workspace: 'seqerakit-e2e/showcase'
@@ -161,12 +161,12 @@ pipelines:
     params-file: './examples/yaml/pipelines/nf_core_viralrecon_illumina_params.yml'
     config: './examples/yaml/pipelines/nextflow.config'
     pre-run: './examples/yaml/pipelines/pre_run.txt'
-    overwrite: True
+    on_exists: overwrite
   - name: 'nf-sentieon'
     workspace: 'seqerakit-e2e/showcase'
     compute-env: 'seqera_aws_virginia_fusionv2_nvme'
     file-path: './examples/yaml/pipelines/nf_sentieon_pipeline.json'
-    overwrite: True
+    on_exists: overwrite
 launch:
   - name: 'nf-core-rnaseq-launchpad'
     workspace: 'seqerakit-e2e/showcase'

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser(
-        description="Build a Seqera Platform instance from a YAML configuration file."
+        description="Create resources on Seqera Platform using a YAML configuration file."
     )
     # General options
     general = parser.add_argument_group("General Options")

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -174,7 +174,12 @@ class BlockParser:
         }
 
         # Get the on_exists option from args for backward compatibility
-        on_exists = args.get("on_exists", OnExists.FAIL)
+        on_exists = args.get("on_exists", "fail")
+        if isinstance(on_exists, str):
+            try:
+                on_exists = OnExists[on_exists.upper()]
+            except KeyError:
+                on_exists = OnExists.FAIL
 
         # Global settings take precedence over block-level settings
         # First check the global --on-exists parameter
@@ -188,9 +193,11 @@ class BlockParser:
             on_exists = OnExists.OVERWRITE
 
         if not dryrun:
-            logging.debug(
-                f" on_exists is set to '{on_exists.name.lower()}' for {block}\n"
+            # Use on_exists.name.lower() only if it's an enum, otherwise use the string
+            on_exists_str = (
+                on_exists.name.lower() if hasattr(on_exists, "name") else on_exists
             )
+            logging.debug(f" on_exists is set to '{on_exists_str}' for {block}\n")
             should_continue = self.overwrite_method.handle_overwrite(
                 block, args["cmd_args"], on_exists=on_exists
             )

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -175,7 +175,17 @@ def parse_block(block_name, item):
 
     # Call the appropriate function and return its result along with on_exists value.
     cmd_args = parse_fn(item)
-    return {"cmd_args": cmd_args, "on_exists": on_exists}
+
+    # Return both on_exists and overwrite for backward compatibility
+    # This allows existing tests to continue using overwrite key
+    # while new code can use the on_exists key
+    result = {"cmd_args": cmd_args, "on_exists": on_exists}
+
+    # Set overwrite boolean for test compatibility
+    # If on_exists is 'overwrite', set overwrite to True, otherwise False
+    result["overwrite"] = on_exists == "overwrite"
+
+    return result
 
 
 # Parsers for certain blocks of yaml that require handling

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -169,7 +169,7 @@ def parse_block(block_name, item):
     overwrite = item.pop("overwrite", None)
     on_exists_str = item.pop("on_exists", "fail")
 
-    # Convert string to enum
+    # Convert string to enum if needed
     if isinstance(on_exists_str, str):
         on_exists_str = on_exists_str.upper()
         try:
@@ -189,14 +189,8 @@ def parse_block(block_name, item):
     # Call the appropriate function and return its result along with on_exists value.
     cmd_args = parse_fn(item)
 
-    # Return both on_exists and overwrite for backward compatibility
-    result = {"cmd_args": cmd_args, "on_exists": on_exists.name.lower()}
-
-    # Set overwrite boolean for test compatibility
-    # If on_exists is 'overwrite', set overwrite to True, otherwise False
-    result["overwrite"] = on_exists == OnExists.OVERWRITE
-
-    return result
+    # Return only the string value of on_exists for test compatibility
+    return {"cmd_args": cmd_args, "on_exists": on_exists.name.lower()}
 
 
 # Parsers for certain blocks of yaml that require handling

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -163,11 +163,19 @@ def parse_block(block_name, item):
     }
     # Use the generic block function as a default.
     parse_fn = block_to_function.get(block_name, parse_generic_block)
-    overwrite = item.pop("overwrite", False)
 
-    # Call the appropriate function and return its result along with overwrite value.
+    # Handle both old and new parameters for backward compatibility
+    overwrite = item.pop("overwrite", None)
+    on_exists = item.pop("on_exists", "fail")
+
+    # If overwrite is specified,
+    # it takes precedence over on_exists for backward compatibility
+    if overwrite is not None:
+        on_exists = "overwrite" if overwrite else "fail"
+
+    # Call the appropriate function and return its result along with on_exists value.
     cmd_args = parse_fn(item)
-    return {"cmd_args": cmd_args, "overwrite": overwrite}
+    return {"cmd_args": cmd_args, "on_exists": on_exists}
 
 
 # Parsers for certain blocks of yaml that require handling

--- a/seqerakit/on_exists.py
+++ b/seqerakit/on_exists.py
@@ -1,0 +1,9 @@
+from enum import Enum, auto
+
+
+class OnExists(Enum):
+    """Enum defining behavior when a resource already exists."""
+
+    FAIL = auto()
+    IGNORE = auto()
+    OVERWRITE = auto()

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -178,10 +178,10 @@ class Overwrite:
                     self.delete_resource(block, operation, sp_args)
                 else:  # fail
                     raise ResourceExistsError(
-                        f" The {block} resource already exists and"
-                        " will not be created. Please set 'on_exists: overwrite' "
-                        " to replace the resource or set 'on_exists: ignore' to "
-                        " ignore this error.\n"
+                        f"The {block} resource already exists and "
+                        "will not be created. Please set 'on_exists: overwrite' "
+                        "to replace the resource or set 'on_exists: ignore' to "
+                        "ignore this error.\n"
                     )
             return True
         return True

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -167,8 +167,9 @@ class Overwrite:
                 else:  # fail
                     raise ResourceExistsError(
                         f" The {block} resource already exists and"
-                        " will not be created. Please set 'on_exists: overwrite'"
-                        " or 'on_exists: ignore' in your config file.\n"
+                        " will not be created. Please set 'on_exists: overwrite' "
+                        " to replace the resource or set 'on_exists: ignore' to "
+                        " ignore this error.\n"
                     )
             return True
         return True

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -117,9 +117,8 @@ class Overwrite:
         """
         # Convert string to enum if needed
         if isinstance(on_exists, str):
-            on_exists_str = on_exists.upper()
             try:
-                on_exists = OnExists[on_exists_str]
+                on_exists = OnExists[on_exists.upper()]
             except KeyError:
                 raise ValueError(
                     f"Invalid on_exists option: {on_exists}. "
@@ -129,13 +128,6 @@ class Overwrite:
         # For backward compatibility
         if overwrite is not None:
             on_exists = OnExists.OVERWRITE if overwrite else OnExists.FAIL
-
-        # Validate on_exists parameter (should always be valid if it's an enum)
-        if on_exists.name.lower() not in self.VALID_ON_EXISTS_OPTIONS:
-            raise ValueError(
-                f"Invalid on_exists option: {on_exists_str}. "
-                f"Valid options are: {', '.join(self.VALID_ON_EXISTS_OPTIONS)}"
-            )
 
         if block in Overwrite.generic_deletion:
             self.block_operations[block] = {

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -15,8 +15,8 @@
 import json
 from seqerakit import utils
 from seqerakit.seqeraplatform import ResourceExistsError
-import logging
 from seqerakit.on_exists import OnExists
+import logging
 
 
 class Overwrite:
@@ -49,9 +49,10 @@ class Overwrite:
         sp: A SeqeraPlatform class instance.
 
         Attributes:
-        sp: A SeqeraPlatform class instance.
-        block_jsondata: A dictionary to cache JSON data for resources.
-        block_operations: A dictionary mapping resource types to their operations.
+        sp: A SeqeraPlatform class instance used to execute CLI commands.
+        cached_jsondata: A cached placeholder for JSON data. Default value is None.
+        block_jsondata: A dictionary to store JSON data for each block.
+        Key is the block name, and value is the corresponding JSON data.
         """
         self.sp = sp
         self.cached_jsondata = None
@@ -326,6 +327,7 @@ class Overwrite:
                 with self.sp.suppress_output():
                     self.cached_jsondata = json_method(block, "list")
 
+        self.block_jsondata[block] = self.cached_jsondata
         return self.cached_jsondata, sp_args
 
     def check_resource_exists(self, name_key, sp_args):

--- a/templates/actions.yml
+++ b/templates/actions.yml
@@ -21,4 +21,4 @@ actions:
     profile: 'test'                                       # optional
     params:                                               # optional
       outdir: 's3://my_bucket/my_results'
-    on_exists: overwrite                                       # optional
+    on_exists: overwrite                                  # optional

--- a/templates/actions.yml
+++ b/templates/actions.yml
@@ -10,7 +10,7 @@ actions:
     profile: 'test'                                       # optional
     params:                                               # optional
       outdir: 's3://my_bucket/my_results'
-    on_exists: overwrite                                       # optional
+    on_exists: overwrite                                   # optional
   - type: 'tower'                                         # required
     name: 'my_tower_action'                               # required
     pipeline: 'https://github.com/my_username/my_repo'    # required

--- a/templates/actions.yml
+++ b/templates/actions.yml
@@ -10,7 +10,7 @@ actions:
     profile: 'test'                                       # optional
     params:                                               # optional
       outdir: 's3://my_bucket/my_results'
-    overwrite: True                                       # optional
+    on_exists: overwrite                                       # optional
   - type: 'tower'                                         # required
     name: 'my_tower_action'                               # required
     pipeline: 'https://github.com/my_username/my_repo'    # required
@@ -21,4 +21,4 @@ actions:
     profile: 'test'                                       # optional
     params:                                               # optional
       outdir: 's3://my_bucket/my_results'
-    overwrite: True                                       # optional
+    on_exists: overwrite                                       # optional

--- a/templates/compute-envs.yml
+++ b/templates/compute-envs.yml
@@ -9,15 +9,15 @@ compute-envs:
     credentials: 'my_aws_credentials'                               # required
     wait: 'AVAILABLE'                                               # optional
     file-path: './compute-envs/my_aws_compute_environment.json'     # required
-    overwrite: True                                                 # optional
-    
+    on_exists: overwrite                                                 # optional
+
 # To create a compute environment with options specified through YAML (AWS Example)
   - type: aws-batch                                                 # required
     config-mode: forge                                              # required for AWS and Azure
     name: 'my_aws_compute_environment'                              # required
     workspace: 'my_organization/my_workspace'                       # optional
     credentials: 'my_aws_credentials'                               # required
-    region: 'eu-west-1'                                             # required 
+    region: 'eu-west-1'                                             # required
     work-dir: 's3://my-bucket'                                      # required
     provisioning-model: 'SPOT'                                      # optional
     fusion-v2: False                                                # optional
@@ -25,12 +25,12 @@ compute-envs:
     fargate: False                                                  # optional
     fast-storage: False                                             # optional
     instance-types: 'c6i,r6i,m6i'                                   # optional, comma separated list
-    no-ebs-auto-scale: True                                         # optional                   
+    no-ebs-auto-scale: True                                         # optional
     max-cpus: 500                                                   # required
     labels: 'label1,label2'                                         # optional, comma separated list
-    vpc-id: 'vpc-1234567890'                                        # optional            
+    vpc-id: 'vpc-1234567890'                                        # optional
     subnets: 'subnet-1234567890,subnet-1234567891'                  # optional, comma separated list
     security-groups: 'sg-1234567890,sg-1234567891'                  # optional, comma separated list
     allow-buckets: 's3://my-bucket,s3://my-other-bucket'            # optional, comma separated list
-    wait: 'AVAILABLE'                                               # optional                     
-    overwrite: False                                                # optional
+    wait: 'AVAILABLE'                                               # optional
+    on_exists: ignore                                               # optional

--- a/templates/compute-envs.yml
+++ b/templates/compute-envs.yml
@@ -9,7 +9,7 @@ compute-envs:
     credentials: 'my_aws_credentials'                               # required
     wait: 'AVAILABLE'                                               # optional
     file-path: './compute-envs/my_aws_compute_environment.json'     # required
-    on_exists: overwrite                                                 # optional
+    on_exists: overwrite                                             # optional
 
 # To create a compute environment with options specified through YAML (AWS Example)
   - type: aws-batch                                                 # required

--- a/templates/credentials.yml
+++ b/templates/credentials.yml
@@ -7,26 +7,26 @@ credentials:
     workspace: 'my_organization/my_workspace'   # optional
     username: 'my_username'                     # required
     password: '$SEQPLATFORM_GITHUB_PASSWORD'    # required
-    overwrite: True                             # optional
+    on_exists: overwrite                        # optional
   - type: 'container-reg'                       # required
     name: 'my_dockerhub_credentials'            # required
     workspace: 'my_organization/my_workspace'   # required
     username: 'my_username'                     # required
     password: '$DOCKERHUB_PASSWORD'             # required
     registry: 'docker.io'                       # required
-    overwrite: True                             # optional
+    on_exists: overwrite                        # optional
   - type: 'google'                              # required
     name: 'my_google_credentials'               # required
     workspace: 'my_organization/my_workspace'   # optional
     key: '$GOOGLE_KEY'                          # required
-    overwrite: True                             # optional
+    on_exists: overwrite                        # optional
   - type: 'aws'                                 # required
     name: 'my_aws_credentials'                  # required
     workspace: 'my_organization/my_workspace'   # optional
     access-key: '$AWS_ACCESS_KEY_ID'            # required
     secret-key: '$AWS_SECRET_ACCESS_KEY'        # required
     assume-role-arn: '$AWS_ASSUME_ROLE_ARN'     # required
-    overwrite: True                             # optional
+    on_exists: overwrite                        # optional
   - type: 'azure'                               # required
     name: 'my_azure_credentials'                # required
     workspace: 'my_organization/my_workspace'   # optional
@@ -34,11 +34,11 @@ credentials:
     batch-name: 'my_storage_name'               # required
     storage-key: '$AZURE_STORAGE_KEY'           # required
     storage-name: 'my_storage_name'             # required
-    overwrite: True                             # optional
+    on_exists: overwrite                        # optional
   - type: 'codecommit'                          # required
     name: 'codecommit_credentials'              # required
     workspace: 'my_organization/my_workspace'   # required
     access-key: '$CODECOMMIT_USER'              # required
     secret-key: '$CODECOMMIT_PASSWORD'          # required
     base-url: '$CODECOMMIT_BASEURL'             # optional
-    overwrite: False                            # optional
+    on_exists: ignore                           # optional

--- a/templates/data-links.yml
+++ b/templates/data-links.yml
@@ -8,7 +8,7 @@ data-links:
     provider: "aws"                                                   # required
     credentials: "my_aws_credentials"                                 # optional
     uri: "s3://my-bucket/my-results/"                                 # required
-    on_exists: ignore                                                  # optional
+    on_exists: ignore                                                 # optional
 
 # Creating a public data link
   - name: "1000-genomes"                                              # required
@@ -16,4 +16,4 @@ data-links:
     description: "Public data link to 1000 genomes public bucket"     # optional
     provider: "aws"                                                   # required
     uri: "s3://1000genomes"                                           # required
-    on_exists: ignore                                                  # optional
+    on_exists: ignore                                                 # optional

--- a/templates/data-links.yml
+++ b/templates/data-links.yml
@@ -8,7 +8,7 @@ data-links:
     provider: "aws"                                                   # required
     credentials: "my_aws_credentials"                                 # optional
     uri: "s3://my-bucket/my-results/"                                 # required
-    overwrite: False                                                  # optional
+    on_exists: ignore                                                  # optional
 
 # Creating a public data link
   - name: "1000-genomes"                                              # required
@@ -16,4 +16,4 @@ data-links:
     description: "Public data link to 1000 genomes public bucket"     # optional
     provider: "aws"                                                   # required
     uri: "s3://1000genomes"                                           # required
-    overwrite: False                                                  # optional
+    on_exists: ignore                                                  # optional

--- a/templates/datasets.yml
+++ b/templates/datasets.yml
@@ -4,5 +4,5 @@ datasets:
     description: 'My test dataset'            # optional
     header: true                              # optional
     workspace: 'my_organization/my_workspace' # optional
-    file-path: './datasets/my_dataset.csv'    # required
-    overwrite: True                           # optional
+    file-path: './datasets/my_dataset.csv'     # required
+    on_exists: overwrite                      # optional

--- a/templates/datasets.yml
+++ b/templates/datasets.yml
@@ -4,5 +4,5 @@ datasets:
     description: 'My test dataset'            # optional
     header: true                              # optional
     workspace: 'my_organization/my_workspace' # optional
-    file-path: './datasets/my_dataset.csv'     # required
+    file-path: './datasets/my_dataset.csv'    # required
     on_exists: overwrite                      # optional

--- a/templates/labels.yml
+++ b/templates/labels.yml
@@ -3,4 +3,4 @@ labels:
   - name: 'label_name'                          # required
     value: 'label_value'                        # required
     workspace: 'my_organization/my_workspace'   # optional
-    overwrite: True                             # optional
+    on_exists: overwrite                        # optional

--- a/templates/members.yml
+++ b/templates/members.yml
@@ -2,4 +2,4 @@
 participants:
   - user: 'bob@myorg.io'                           # required
     organization: 'myorg'                          # required
-    overwrite: True                                # optional
+    on_exists: overwrite                           # optional

--- a/templates/organizations.yml
+++ b/templates/organizations.yml
@@ -5,4 +5,4 @@ organizations:
     description: 'My test organisation'   # optional
     location: 'Global'                    # optional
     website: 'https://my_organization/'   # optional
-    overwrite: True                       # optional
+    on_exists: overwrite                  # optional

--- a/templates/pipelines.yml
+++ b/templates/pipelines.yml
@@ -3,16 +3,16 @@
 ##   1. Explicitly in this file
 ##   2. Via a JSON file exported from SeqeraPlatform with the "tw pipelines export" command
 pipelines:
-  - name: 'my_first_pipeline'                          # required
+  - name: 'my_first_pipeline'                         # required
     workspace: 'my_organization/my_workspace'         # optional
     description: 'My test pipeline'                   # optional
     compute-env: 'my_aws_compute_environment'         # required
     work-dir: 's3://my_bucket'                        # optional
-    profile: 'test'                                    # optional
+    profile: 'test'                                   # optional
     revision: 'main'                                  # required
     params:                                           # optional
       outdir: 's3://my-bucket/my_results'
-    config: './pipelines/my_nextflow.config'             # optional
+    config: './pipelines/my_nextflow.config'          # optional
     pre-run: './pipelines/my_pre_run.txt'             # optional
     url: 'https://github.com/my_username/my_repo'     # required
                                        # optional
@@ -20,5 +20,5 @@ pipelines:
     workspace: 'my_organization/my_workspace'         # optional
     description: 'My test pipeline'                   # optional
     compute-env: 'my_aws_compute_environment'         # required
-    file-path: './pipelines/my_pipeline.json'          # required
+    file-path: './pipelines/my_pipeline.json'         # required
     on_exists: overwrite                              # optional

--- a/templates/pipelines.yml
+++ b/templates/pipelines.yml
@@ -3,22 +3,22 @@
 ##   1. Explicitly in this file
 ##   2. Via a JSON file exported from SeqeraPlatform with the "tw pipelines export" command
 pipelines:
-  - name: 'my_first_pipeline'                         # required
+  - name: 'my_first_pipeline'                          # required
     workspace: 'my_organization/my_workspace'         # optional
     description: 'My test pipeline'                   # optional
     compute-env: 'my_aws_compute_environment'         # required
     work-dir: 's3://my_bucket'                        # optional
-    profile: 'test'                                   # optional
+    profile: 'test'                                    # optional
     revision: 'main'                                  # required
     params:                                           # optional
       outdir: 's3://my-bucket/my_results'
-    config: './pipelines/my_nextflow.config'          # optional
+    config: './pipelines/my_nextflow.config'             # optional
     pre-run: './pipelines/my_pre_run.txt'             # optional
     url: 'https://github.com/my_username/my_repo'     # required
-    overwrite: True                                   # optional
+                                       # optional
   - name: 'my_second_pipeline'                        # required
     workspace: 'my_organization/my_workspace'         # optional
     description: 'My test pipeline'                   # optional
     compute-env: 'my_aws_compute_environment'         # required
-    file-path: './pipelines/my_pipeline.json'         # required
-    overwrite: True                                   # optional
+    file-path: './pipelines/my_pipeline.json'          # required
+    on_exists: overwrite                              # optional

--- a/templates/secrets.yml
+++ b/templates/secrets.yml
@@ -3,4 +3,4 @@ secrets:
   - name: 'my_secret'                         # required
     workspace: 'my_organization/my_workspace' # optional
     value: 'my_secret_value'                  # required
-    overwrite: True                           # optional
+    on_exists: overwrite                      # optional

--- a/templates/studios.yml
+++ b/templates/studios.yml
@@ -18,7 +18,7 @@ studios:
     memory: 4096                                                              # optional
     autoStart: True                                                           # optional
     mount-data-resource-refs: 's3://my_bucket/my_data'                        # optional, comma separated list
-    overwrite: False                                                          # optional
+    on_exists: ignore                                                          # optional
 
 # Mounting with a custom template
   - name: 'rstudio_environment_custom_template'                                 # required
@@ -31,7 +31,7 @@ studios:
     memory: 4096                                                                # optional
     autoStart: True                                                             # optional
     mount-data-resource-refs: 's3://my_bucket/my_data'                          # optional, comma separated list
-    overwrite: False                                                            # optional
+    on_exists: ignore                                                            # optional
 
 # Mounting with a template image customized with conda packages
   - name: 'rstudio_environment_conda_packages'                                  # required
@@ -45,4 +45,4 @@ studios:
     memory: 4096                                                                # optional
     autoStart: True                                                             # optional
     mount-data-resource-refs: 's3://my_bucket/my_data'                          # optional, comma separated list
-    overwrite: False                                                            # optional
+    on_exists: ignore                                                            # optional

--- a/templates/teams.yml
+++ b/templates/teams.yml
@@ -5,4 +5,4 @@ teams:
     description: 'My test team'     # optional
     members:                        # optional
       - 'my_team_member@gmail.com'
-    overwrite: True                 # optional
+    on_exists: 'overwrite'          # optional - values: 'fail' (default), 'ignore', 'overwrite'

--- a/templates/workspaces.yml
+++ b/templates/workspaces.yml
@@ -5,4 +5,4 @@ workspaces:
     organization: 'my_organization'   # required
     description: 'My test workspace'  # optional
     visibility: 'PRIVATE'             # optional
-    overwrite: True                   # optional
+    on_exists: overwrite              # optional

--- a/tests/e2e/aws-e2e.yml
+++ b/tests/e2e/aws-e2e.yml
@@ -3,52 +3,52 @@ organizations:
   - name: '$SEQERA_ORGANIZATION_NAME'
     full-name: '$SEQERA_ORGANIZATION_NAME'
     description: 'Example of an organization'
-    overwrite: True
+    on_exists: overwrite
 teams:
   - name: '$SEQERA_TEAM_NAME'
     organization: '$SEQERA_ORGANIZATION_NAME'
     description: 'Example of a team'
     members:
       - '$TEAM_MEMBER_EMAIL1'
-    overwrite: True
+    on_exists: overwrite
 workspaces:
   - name: '$SEQERA_WORKSPACE_NAME'
     full-name: '$SEQERA_WORKSPACE_NAME'
     organization: '$SEQERA_ORGANIZATION_NAME'
     visibility: 'PRIVATE'
-    overwrite: True
+    on_exists: overwrite
 participants:
   - name: '$SEQERA_TEAM_NAME'
     type: 'TEAM'
     workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
     role: 'ADMIN'
-    overwrite: True
+    on_exists: overwrite
 credentials:
   - type: 'github'
     name: 'github_credentials'
     workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
     username: '$SEQERA_GITHUB_USERNAME'
     password: '$SEQERA_GITHUB_PASSWORD'
-    overwrite: True
+    on_exists: overwrite
   - type: 'container-reg'
     name: 'dockerhub_credentials'
     workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
     username: '$DOCKERHUB_USERNAME'
     password: '$DOCKERHUB_PASSWORD'
     registry: 'docker.io'
-    overwrite: True
+    on_exists: overwrite
   - type: 'aws'
     name: 'aws_credentials'
     workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
     access-key: '$AWS_ACCESS_KEY_ID'
     secret-key: '$AWS_SECRET_ACCESS_KEY'
     assume-role-arn: '$AWS_ASSUME_ROLE_ARN'
-    overwrite: True
+    on_exists: overwrite
 secrets:
   - name: 'SENTIEON_LICENSE_BASE64'
     workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
     value: '$SENTIEON_LICENSE_BASE64'
-    overwrite: True
+    on_exists: overwrite
 compute-envs:
   - type: aws-batch
     config-mode: forge
@@ -65,14 +65,14 @@ compute-envs:
     no-ebs-auto-scale: True
     max-cpus: 500
     wait: AVAILABLE
-    overwrite: True
+    on_exists: overwrite
 datasets:
   - name: '$DATASET_NAME_PREFIX-rnaseq-samples'
     description: 'Samplesheet to run the nf-core/rnaseq pipeline from end-to-end'
     header: true
     workspace: '$SEQERA_ORGANIZATION_NAME/$SEQERA_WORKSPACE_NAME'
     file-path: './examples/yaml/datasets/rnaseq_samples.csv'
-    overwrite: True
+    on_exists: overwrite
 pipelines:
   - name: '$PIPELINE_NAME_PREFIX-hello-world'
     url: 'https://github.com/nextflow-io/hello'
@@ -81,4 +81,4 @@ pipelines:
     compute-env: '$AWS_COMPUTE_ENV_NAME'
     work-dir: '$SEQERA_WORK_DIR'
     revision: 'master'
-    overwrite: True
+    on_exists: overwrite

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -28,7 +28,7 @@ def test_create_mock_organization_yaml(mock_yaml_file):
                 "description": "My test organization 1",
                 "location": "Global",
                 "url": "https://example.com",
-                "overwrite": True,
+                "on_exists": "overwrite",
             }
         ]
     }
@@ -46,7 +46,7 @@ def test_create_mock_organization_yaml(mock_yaml_file):
                 "--url",
                 "https://example.com",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -66,7 +66,7 @@ def test_create_mock_workspace_yaml(mock_yaml_file):
                 "organization": "my_organization",
                 "description": "My test workspace 1",
                 "visibility": "PRIVATE",
-                "overwrite": True,
+                "on_exists": "overwrite",
             }
         ]
     }
@@ -84,7 +84,7 @@ def test_create_mock_workspace_yaml(mock_yaml_file):
                 "--visibility",
                 "PRIVATE",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
 
@@ -104,7 +104,7 @@ def test_create_mock_dataset_yaml(mock_yaml_file):
                 "workspace": "my_organization/my_workspace",
                 "header": True,
                 "file-path": "./examples/yaml/datasets/samples.csv",
-                "overwrite": True,
+                "on_exists": "overwrite",
             }
         ]
     }
@@ -120,7 +120,7 @@ def test_create_mock_dataset_yaml(mock_yaml_file):
                 "My test dataset 1",
                 "--header",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
 
@@ -142,7 +142,7 @@ def test_create_mock_computeevs_source_yaml(mock_yaml_file):
                 "wait": "AVAILABLE",
                 "fusion-v2": True,
                 "fargate": False,
-                "overwrite": True,
+                "on_exists": "overwrite",
             }
         ],
     }
@@ -161,7 +161,7 @@ def test_create_mock_computeevs_source_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
 
@@ -200,7 +200,7 @@ def test_create_mock_computeevs_cli_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "overwrite": False,
+            "on_exists": "fail",
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -224,7 +224,7 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
                 "config": "./examples/yaml/pipelines/test_pipeline1/config.txt",
                 "pre-run": "./examples/yaml/pipelines/test_pipeline1/pre_run.sh",
                 "revision": "master",
-                "overwrite": True,
+                "on_exists": "overwrite",
                 "stub-run": True,
             }
         ]
@@ -256,7 +256,7 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
                 "--params-file",
                 "./examples/yaml/pipelines/test_pipeline1/params.yaml",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
 
@@ -275,7 +275,7 @@ def test_create_mock_teams_yaml(mock_yaml_file):
                 "organization": "my_organization",
                 "description": "My test team 1",
                 "members": ["user1@org.io"],
-                "overwrite": True,
+                "on_exists": "overwrite",
             },
         ]
     }
@@ -302,7 +302,7 @@ def test_create_mock_teams_yaml(mock_yaml_file):
                     ]
                 ],
             ),
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
 
@@ -323,7 +323,7 @@ def test_create_mock_members_yaml(mock_yaml_file):
                 "--user",
                 "bob@myorg.io",
             ],
-            "overwrite": False,
+            "on_exists": "fail",
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -344,7 +344,7 @@ def test_create_mock_studios_yaml(mock_yaml_file):
                 "cpu": 2,
                 "memory": 4096,
                 "autoStart": False,
-                "overwrite": True,
+                "on_exists": "overwrite",
                 "mount-data-ids": "v1-user-bf73f9d33997f93a20ee3e6911779951",
             }
         ]
@@ -368,7 +368,7 @@ def test_create_mock_studios_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
 
@@ -388,7 +388,7 @@ def test_create_mock_data_links_yaml(mock_yaml_file):
                 "provider": "aws",
                 "credentials": "my_credentials",
                 "uri": "s3://scidev-playground-eu-west-2/esha/nf-core-scrnaseq/",
-                "overwrite": True,
+                "on_exists": "overwrite",
             }
         ]
     }
@@ -406,7 +406,7 @@ def test_create_mock_data_links_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "overwrite": True,
+            "on_exists": "overwrite",
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -466,7 +466,7 @@ compute-envs:
                 "--wait",
                 "AVAILABLE",
             ],
-            "overwrite": False,
+            "on_exists": "fail",
         }
     ]
     assert "compute-envs" in result
@@ -549,7 +549,7 @@ pipelines:
     expected_organizations_output = [
         {
             "cmd_args": ["--name", "org1", "--description", "Organization 1"],
-            "overwrite": False,
+            "on_exists": "fail",
         }
     ]
     expected_workspaces_output = [
@@ -562,7 +562,7 @@ pipelines:
                 "--description",
                 "Workspace 1",
             ],
-            "overwrite": False,
+            "on_exists": "fail",
         }
     ]
     # Check that only 'organizations' and 'workspaces' are in the result

--- a/tests/unit/test_overwrite.py
+++ b/tests/unit/test_overwrite.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import json
 from seqerakit.overwrite import Overwrite
 from seqerakit.seqeraplatform import ResourceExistsError
+from seqerakit.on_exists import OnExists
 
 
 class TestOverwrite(unittest.TestCase):
@@ -43,7 +44,9 @@ class TestOverwrite(unittest.TestCase):
             {"name": "test-resource"}
         )
 
-        self.overwrite.handle_overwrite("credentials", args, overwrite=True)
+        self.overwrite.handle_overwrite(
+            "credentials", args, on_exists=OnExists.OVERWRITE
+        )
 
         self.mock_sp.credentials.assert_called_with(
             "delete", "--name", "test-resource", "--workspace", "test-workspace"
@@ -58,7 +61,9 @@ class TestOverwrite(unittest.TestCase):
         )
 
         with self.assertRaises(ResourceExistsError):
-            self.overwrite.handle_overwrite("credentials", args, overwrite=False)
+            self.overwrite.handle_overwrite(
+                "credentials", args, on_exists=OnExists.FAIL
+            )
 
     def test_team_deletion(self):
         args = {"name": "test-team", "organization": "test-org"}
@@ -92,7 +97,9 @@ class TestOverwrite(unittest.TestCase):
 
         self.mock_sp.__getattr__("-o json").return_value = self.sample_workspace_json
 
-        self.overwrite.handle_overwrite("workspaces", args, overwrite=True)
+        self.overwrite.handle_overwrite(
+            "workspaces", args, on_exists=OnExists.OVERWRITE
+        )
 
         self.mock_sp.workspaces.assert_called_with("delete", "--id", "456")
 
@@ -108,7 +115,7 @@ class TestOverwrite(unittest.TestCase):
 
         self.mock_sp.__getattr__("-o json").return_value = self.sample_labels_json
 
-        self.overwrite.handle_overwrite("labels", args, overwrite=True)
+        self.overwrite.handle_overwrite("labels", args, on_exists=OnExists.OVERWRITE)
 
         self.mock_sp.labels.assert_called_with(
             "delete", "--id", "789", "-w", "test-workspace"
@@ -128,7 +135,9 @@ class TestOverwrite(unittest.TestCase):
             {"teamName": "test-team"}
         )
 
-        self.overwrite.handle_overwrite("participants", team_args, overwrite=True)
+        self.overwrite.handle_overwrite(
+            "participants", team_args, on_exists=OnExists.OVERWRITE
+        )
 
         self.mock_sp.participants.assert_called_with(
             "delete",
@@ -159,7 +168,9 @@ class TestOverwrite(unittest.TestCase):
 
         self.mock_sp.configure_mock(**{"-o json": json_method_mock})
 
-        self.overwrite.handle_overwrite("organizations", args, overwrite=True)
+        self.overwrite.handle_overwrite(
+            "organizations", args, on_exists=OnExists.OVERWRITE
+        )
 
         mock_resolve_env_var.assert_any_call("${ORG_NAME}")
 


### PR DESCRIPTION
This PR adds a feature where you can customize the behaviour when a resource exists. It has three options:

- `fail` (default): Fail and halt seqerakit
- `ignore`: Keep going and ignore the error
- `overwrite`: Use the existing overwrite behaviour

With this, we can repeatedly set up a 'showcase' and it will only create resources where they don't exist and launch pipelines, meaning we can be fairly frugal with resource set up.

The downside is status drift may occur, where the platform resources have diverged from the YAML templates which will not be captured and will be ignored by seqerakit. Not ideal, but a problem even for things like [Terraform](https://developer.hashicorp.com/terraform/tutorials/state/resource-drift).