### PR TITLE
feat: resolve dataset names to urls if in params dict

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -281,10 +281,7 @@ def main(args=None):
     # and get a dictionary of command line arguments
     try:
         cmd_args_dict = helper.parse_all_yaml(
-            yaml_files, 
-            destroy=options.delete, 
-            targets=options.targets,
-            sp=sp
+            yaml_files, destroy=options.delete, targets=options.targets, sp=sp
         )
         for block, args_list in cmd_args_dict.items():
             for args in args_list:

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -281,7 +281,10 @@ def main(args=None):
     # and get a dictionary of command line arguments
     try:
         cmd_args_dict = helper.parse_all_yaml(
-            yaml_files, destroy=options.delete, targets=options.targets
+            yaml_files, 
+            destroy=options.delete, 
+            targets=options.targets,
+            sp=sp
         )
         for block, args_list in cmd_args_dict.items():
             for args in args_list:

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -153,14 +153,15 @@ def parse_all_yaml(file_paths, destroy=False, targets=None, sp=None):
 def parse_block(block_name, item, sp=None):
     # Define the mapping from block names to functions.
     block_to_function = {
-        "credentials": parse_type_block,
-        "compute-envs": parse_type_block,
-        "actions": parse_type_block,
+        "credentials": lambda x, s: parse_type_block(x, sp=s),
+        "compute-envs": lambda x, s: parse_type_block(x, sp=s),
+        "actions": lambda x, s: parse_type_block(x, sp=s),
         "teams": parse_teams_block,
         "datasets": parse_datasets_block,
-        "pipelines": parse_pipelines_block,
+        "pipelines": lambda x, s: parse_pipelines_block(x, sp=s),
         "launch": parse_launch_block,
     }
+
     # Use the generic block function as a default.
     parse_fn = block_to_function.get(block_name, parse_generic_block)
     overwrite = item.pop("overwrite", False)
@@ -293,14 +294,7 @@ def resolve_dataset_reference(params_dict, workspace, sp):
         del processed_params["dataset"]
 
     except Exception as e:
-        if "No dataset" in str(e):
-            raise ValueError(
-                f"Dataset '{dataset_name}' not found in workspace '{workspace}'. "
-                "Please check the dataset name and workspace."
-            )
-        raise ValueError(
-            f"Failed to retrieve URL for dataset '{dataset_name}': {str(e)}"
-        )
+        raise ValueError(f"Failed to resolve dataset '{dataset_name}': {str(e)}")
 
     return processed_params
 

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -187,9 +187,9 @@ def parse_block(block_name, item, sp=None):
         # Use directly if already an enum
         on_exists = on_exists_str
 
-    # Parse the block and return with on_exists value
-    cmd_args = parse_fn(item)
-    return {"cmd_args": cmd_args, "on_exists": on_exists.name.lower()}
+    cmd_args = parse_fn(item, sp) if "lambda" in str(parse_fn) else parse_fn(item)
+
+    return {"cmd_args": cmd_args, "on_exists": on_exists}
 
 
 # Parsers for certain blocks of yaml that require handling

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, mock_open
 from seqerakit import helper
+from seqerakit.on_exists import OnExists
 import yaml
 import pytest
 from io import StringIO
@@ -61,7 +62,7 @@ def test_create_mock_organization_yaml(mock_yaml_file):
                 "--url",
                 "https://example.com",
             ],
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -99,7 +100,7 @@ def test_create_mock_workspace_yaml(mock_yaml_file):
                 "--visibility",
                 "PRIVATE",
             ],
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
 
@@ -135,7 +136,7 @@ def test_create_mock_dataset_yaml(mock_yaml_file):
                 "My test dataset 1",
                 "--header",
             ],
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
 
@@ -146,7 +147,7 @@ def test_create_mock_dataset_yaml(mock_yaml_file):
     assert result["datasets"] == expected_block_output
 
 
-def test_create_mock_computeevs_source_yaml(mock_yaml_file):
+def test_create_mock_computeevs_source_yaml(mock_yaml_file, mock_seqera_platform):
     test_data = {
         "compute-envs": [
             {
@@ -176,12 +177,12 @@ def test_create_mock_computeevs_source_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
 
     file_path = mock_yaml_file(test_data)
-    result = helper.parse_all_yaml([file_path])
+    result = helper.parse_all_yaml([file_path], sp=mock_seqera_platform)
 
     assert "compute-envs" in result
     assert result["compute-envs"] == expected_block_output
@@ -224,7 +225,7 @@ def test_create_mock_computeevs_cli_yaml(mock_yaml_file):
     actual_args_set = set(actual_args)
 
     assert all(arg in actual_args_set for arg in expected_args)
-    assert not result["compute-envs"][0]["overwrite"]
+    assert result["compute-envs"][0]["on_exists"] == OnExists.FAIL
     assert len(actual_args) == len(expected_args)
 
 
@@ -276,7 +277,7 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
         assert actual_args[key_index + 1] == value
 
     # Check overwrite flag
-    assert result["pipelines"][0]["overwrite"] is True
+    assert result["pipelines"][0]["on_exists"] == OnExists.OVERWRITE
 
 
 def test_create_mock_teams_yaml(mock_yaml_file):
@@ -314,7 +315,7 @@ def test_create_mock_teams_yaml(mock_yaml_file):
                     ]
                 ],
             ),
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
 
@@ -335,7 +336,7 @@ def test_create_mock_members_yaml(mock_yaml_file):
                 "--user",
                 "bob@myorg.io",
             ],
-            "on_exists": "fail",
+            "on_exists": OnExists.FAIL,
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -380,7 +381,7 @@ def test_create_mock_studios_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
 
@@ -418,7 +419,7 @@ def test_create_mock_data_links_yaml(mock_yaml_file):
                 "--workspace",
                 "my_organization/my_workspace",
             ],
-            "on_exists": "overwrite",
+            "on_exists": OnExists.OVERWRITE,
         }
     ]
     file_path = mock_yaml_file(test_data)
@@ -478,7 +479,7 @@ compute-envs:
                 "--wait",
                 "AVAILABLE",
             ],
-            "on_exists": "fail",
+            "on_exists": OnExists.FAIL,
         }
     ]
     assert "compute-envs" in result
@@ -561,7 +562,7 @@ pipelines:
     expected_organizations_output = [
         {
             "cmd_args": ["--name", "org1", "--description", "Organization 1"],
-            "on_exists": "fail",
+            "on_exists": OnExists.FAIL,
         }
     ]
     expected_workspaces_output = [
@@ -574,7 +575,7 @@ pipelines:
                 "--description",
                 "Workspace 1",
             ],
-            "on_exists": "fail",
+            "on_exists": OnExists.FAIL,
         }
     ]
     # Check that only 'organizations' and 'workspaces' are in the result

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -224,7 +224,7 @@ def test_create_mock_computeevs_cli_yaml(mock_yaml_file):
     actual_args_set = set(actual_args)
 
     assert all(arg in actual_args_set for arg in expected_args)
-    assert result["compute-envs"][0]["overwrite"] == False
+    assert not result["compute-envs"][0]["overwrite"]
     assert len(actual_args) == len(expected_args)
 
 

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -18,18 +18,19 @@ def mock_yaml_file(mocker):
 
     return _mock_yaml_file
 
+
 # Fixture to mock SeqeraPlatform instance
 @pytest.fixture
 def mock_seqera_platform(mocker):
     """Fixture for mocked SeqeraPlatform with common setup."""
     mock_sp = mocker.Mock()
-    
+
     # Mock the suppress_output context manager
     mock_context = mocker.MagicMock()
     mock_context.__enter__ = mocker.Mock()
     mock_context.__exit__ = mocker.Mock()
     mock_sp.suppress_output.return_value = mock_context
-    
+
     return mock_sp
 
 
@@ -205,19 +206,23 @@ def test_create_mock_computeevs_cli_yaml(mock_yaml_file):
     result = helper.parse_all_yaml([file_path])
     assert "compute-envs" in result
     actual_args = result["compute-envs"][0]["cmd_args"]
-    
+
     expected_args = {
         "aws-batch",  # type
-        "forge",      # config-mode
-        "--credentials", "my_credentials",
-        "--name", "test_computeenv",
-        "--wait", "AVAILABLE",
-        "--workspace", "my_organization/my_workspace",
+        "forge",  # config-mode
+        "--credentials",
+        "my_credentials",
+        "--name",
+        "test_computeenv",
+        "--wait",
+        "AVAILABLE",
+        "--workspace",
+        "my_organization/my_workspace",
     }
-    
+
     # set for order-independent comparison
     actual_args_set = set(actual_args)
-    
+
     assert all(arg in actual_args_set for arg in expected_args)
     assert result["compute-envs"][0]["overwrite"] == False
     assert len(actual_args) == len(expected_args)
@@ -249,7 +254,7 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
 
     assert "pipelines" in result
     actual_args = result["pipelines"][0]["cmd_args"]
-    
+
     expected_pairs = {
         "--compute-env": "my_computeenv",
         "--config": "./examples/yaml/pipelines/test_pipeline1/config.txt",
@@ -262,14 +267,14 @@ def test_create_mock_pipeline_add_yaml(mock_yaml_file):
         "--workspace": "my_organization/my_workspace",
         "--params-file": "./examples/yaml/pipelines/test_pipeline1/params.yaml",
     }
-    
+
     assert "--stub-run" in actual_args
     assert "https://github.com/nf-core/test_pipeline1" in actual_args
-    
+
     for key, value in expected_pairs.items():
         key_index = actual_args.index(key)
         assert actual_args[key_index + 1] == value
-    
+
     # Check overwrite flag
     assert result["pipelines"][0]["overwrite"] is True
 
@@ -605,16 +610,13 @@ pipelines:
 
 def test_process_params_dict_basic():
     """Test basic params dictionary processing without dataset resolution."""
-    params = {
-        "input": "s3://bucket/data",
-        "outdir": "s3://bucket/results"
-    }
-    
+    params = {"input": "s3://bucket/data", "outdir": "s3://bucket/results"}
+
     result = helper.process_params_dict(params)
     assert len(result) == 2
     assert result[0] == "--params-file"
     # The second argument should be a path to a temp file
-    assert result[1].endswith('.yaml')
+    assert result[1].endswith(".yaml")
 
 
 def test_process_params_dict_with_file_path():
@@ -629,46 +631,55 @@ def test_process_params_dict_empty():
 
 def test_resolve_dataset_reference(mocker, mock_yaml_file, mock_seqera_platform):
     """Test dataset URL resolution."""
-    mock_seqera_platform.datasets.return_value = {"datasetUrl": "https://api.cloud.seqera.io/datasets/123"}
-    
+    mock_seqera_platform.datasets.return_value = {
+        "datasetUrl": "https://api.cloud.seqera.io/datasets/123"
+    }
+
     params = {"dataset": "my_dataset_name"}
     mock_yaml_file(params, "params.yaml")
-    
-    result = helper.resolve_dataset_reference(params, "org/workspace", mock_seqera_platform)
-    
+
+    result = helper.resolve_dataset_reference(
+        params, "org/workspace", mock_seqera_platform
+    )
+
     assert "dataset" not in result
     assert result["input"] == "https://api.cloud.seqera.io/datasets/123"
-    
-    mock_seqera_platform.datasets.assert_called_once_with("url", "-n", "my_dataset_name", "-w", "org/workspace")
+
+    mock_seqera_platform.datasets.assert_called_once_with(
+        "url", "-n", "my_dataset_name", "-w", "org/workspace"
+    )
 
 
 def test_resolve_dataset_reference_error(mocker, mock_seqera_platform):
     """Test dataset resolution error handling."""
     mock_seqera_platform.datasets.return_value = None
-    
+
     params = {"dataset": "nonexistent_dataset"}
     workspace = "org/workspace"
-    
-    with pytest.raises(ValueError, match="No URL found for dataset 'nonexistent_dataset'"):
+
+    with pytest.raises(
+        ValueError, match="No URL found for dataset 'nonexistent_dataset'"
+    ):
         helper.resolve_dataset_reference(params, workspace, mock_seqera_platform)
 
 
 def test_process_params_dict_with_dataset_resolution(mocker, mock_seqera_platform):
     """Test full params processing with dataset resolution."""
-    mock_seqera_platform.datasets.return_value = {"datasetUrl": "https://api.cloud.seqera.io/datasets/123"}
-    
-    params = {
-        "dataset": "my_dataset",
-        "outdir": "s3://bucket/results"
+    mock_seqera_platform.datasets.return_value = {
+        "datasetUrl": "https://api.cloud.seqera.io/datasets/123"
     }
-    
-    result = helper.process_params_dict(params, workspace="org/workspace", sp=mock_seqera_platform)
-    
+
+    params = {"dataset": "my_dataset", "outdir": "s3://bucket/results"}
+
+    result = helper.process_params_dict(
+        params, workspace="org/workspace", sp=mock_seqera_platform
+    )
+
     assert len(result) == 2
     assert result[0] == "--params-file"
-    
+
     # verify temp param file contents
-    with open(result[1], 'r') as f:
+    with open(result[1], "r") as f:
         written_params = yaml.safe_load(f)
         assert written_params["input"] == "https://api.cloud.seqera.io/datasets/123"
         assert written_params["outdir"] == "s3://bucket/results"


### PR DESCRIPTION
This PR adds support for resolving dataset references in pipeline parameters. Users can now reference a dataset by name in their pipeline parameters, and seqerakit will automatically resolve it to the dataset URL.

- Added `resolve_dataset_reference` function to handle dataset URL resolution
- Created `process_params_dict` to standardize params handling across commands
- Added error handling for missing datasets and resolution failures and tests