### PR TITLE
fix: support for nextflow env vars in params

### DIFF
--- a/seqerakit/utils.py
+++ b/seqerakit/utils.py
@@ -159,7 +159,8 @@ def create_temp_yaml(params_dict, params_file=None):
 def resolve_env_var(value):
     """
     Resolves environment variables in a string value.
-    Handles both $VAR and ${VAR} formats.
+    Handles both $VAR and ${VAR} formats, and escaping
+    with $$ to include literal $ characters.
 
     Args:
         value (str): The value that might contain environment variables
@@ -175,10 +176,15 @@ def resolve_env_var(value):
         return value
 
     def _replace(match):
-        var_name = match.group().lstrip("$").strip("{}")
+        matched_text = match.group()
+
+        if matched_text.startswith("$$"):
+            return matched_text[1:]
+
+        var_name = matched_text.lstrip("$").strip("{}")
         var_value = os.getenv(var_name)
         if var_value is None:
             raise EnvironmentError(f"Environment variable {var_name} not found")
         return var_value
 
-    return re.sub(r"\$\{?\w+\}?", _replace, value)
+    return re.sub(r"\$\$|\$\{?\w+\}?", _replace, value)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2023, Seqera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from seqerakit.utils import resolve_env_var
+
+
+class TestResolveEnvVar(unittest.TestCase):
+    """Test cases for the resolve_env_var function"""
+
+    def setUp(self):
+        """Set up test environment variables"""
+        os.environ["TEST_VAR"] = "test_value"
+        os.environ["PROJECT_DIR"] = "/path/to/project"
+        os.environ["OUTPUT_DIR"] = "/path/to/output"
+
+    def tearDown(self):
+        """Clean up test environment variables"""
+        # Remove test environment variables
+        for var in ["TEST_VAR", "PROJECT_DIR", "OUTPUT_DIR"]:
+            if var in os.environ:
+                del os.environ[var]
+
+    def test_basic_env_vars(self):
+        """Test basic environment variable formats"""
+        self.assertEqual(resolve_env_var("$TEST_VAR"), "test_value")
+        self.assertEqual(resolve_env_var("${TEST_VAR}"), "test_value")
+
+    def test_escaping(self):
+        """Test $$ escaping functionality"""
+        self.assertEqual(resolve_env_var("$${projectDir}"), "${projectDir}")
+        self.assertEqual(resolve_env_var("$$$${projectDir}"), "$${projectDir}")
+
+    def test_mixed_cases(self):
+        """Test combinations of escaped and environment variables"""
+        self.assertEqual(
+            resolve_env_var("$${projectDir}/${TEST_VAR}"), "${projectDir}/test_value"
+        )
+        self.assertEqual(
+            resolve_env_var("$${projectDir}/${PROJECT_DIR}"),
+            "${projectDir}//path/to/project",
+        )
+
+    def test_non_env_inputs(self):
+        """Test non-environment variable inputs"""
+        self.assertEqual(resolve_env_var("plain_string"), "plain_string")
+        self.assertEqual(resolve_env_var(""), "")
+        self.assertEqual(resolve_env_var(None), None)
+        self.assertEqual(resolve_env_var(123), 123)
+
+    def test_missing_env_vars(self):
+        """Test missing environment variables raise errors"""
+        with self.assertRaises(EnvironmentError):
+            resolve_env_var("$MISSING_VAR")
+        with self.assertRaises(EnvironmentError):
+            resolve_env_var("${MISSING_VAR}")
+
+        # Escaped patterns should not cause errors
+        self.assertEqual(resolve_env_var("$${MISSING_VAR}"), "${MISSING_VAR}")
+
+    def test_edge_cases(self):
+        """Test edge cases with dollar signs"""
+        self.assertEqual(resolve_env_var("$"), "$")
+        self.assertEqual(resolve_env_var("$$"), "$")
+        self.assertEqual(resolve_env_var("$$$"), "$$")
+
+    def test_nf_reserved_vars(self):
+        """Test Nextflow reserved variables"""
+        result = resolve_env_var("$${projectDir}/${TEST_VAR}")
+        self.assertEqual(result, "${projectDir}/test_value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #243. Currently, we cannot include literal `${}` patterns in YAML parameters (e.g. Nextfow env vars) because seqerakit treats all $ patterns as environment variables.

This PR adds `$$` escaping support to allow literal dollar signs in parameter values.