### PR TITLE
feat: add support for targetting resources by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ seqerakit hello-world-config.yml --cli="-Djavax.net.ssl.trustStore=/absolute/pat
 
 ## Specify targets
 
-When using a YAML file as input that defines multiple resources, you can use the `--targets` flag to specify which resources to create. This flag takes a comma-separated list of resource names.
+When using a YAML file as input that defines multiple resources, you can use the `--targets` flag to specify which resource types to create. This flag takes a comma-separated list of resource types.
 
 For example, given a YAML file that defines the following resources:
 
@@ -289,6 +289,10 @@ pipelines:
     url: 'https://github.com/nextflow-io/hello'
     workspace: 'seqerakit/test'
     compute-env: 'compute-env'
+  - name: 'nf-core-rnaseq'
+    url: 'https://github.com/nf-core/rnaseq'
+    workspace: 'seqerakit/test'
+    compute-env: 'compute-env'
 ```
 
 You can target the creation of `pipelines` only by running:
@@ -305,6 +309,28 @@ You can also specify multiple resources to create by separating them with commas
 
 ```bash
 seqerakit test.yml --targets workspaces,pipelines
+```
+
+### Targeting specific resources by name
+
+Use the `--target` flag to target specific resources by name within a resource type. The format is `--target <resource-type>=<name>`.
+
+For example, to create only the pipeline named `hello-world-test-seqerakit`:
+
+```bash
+seqerakit test.yml --target pipelines=hello-world-test-seqerakit
+```
+
+You can specify multiple names using comma-separated values:
+
+```bash
+seqerakit test.yml --target pipelines=hello-world-test-seqerakit,nf-core-rnaseq
+```
+
+Or use multiple `--target` flags:
+
+```bash
+seqerakit test.yml --target pipelines=hello-world-test-seqerakit --target compute-envs=compute-env
 ```
 
 ## YAML Configuration Options

--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -260,6 +260,12 @@ def main(
         help="Specify the resources to be targeted for creation in a YAML file through "
         "a comma-separated list (e.g. '--targets=teams,participants').",
     ),
+    target: Optional[List[str]] = typer.Option(
+        None,
+        "--target",
+        help="Specify a resource and optionally a name to target "
+        "(e.g. '--target pipelines=my-pipeline'). Can be specified multiple times.",
+    ),
     env_file: Optional[str] = typer.Option(
         None,
         "--env-file",
@@ -355,7 +361,7 @@ def main(
     # and get a dictionary of command line arguments
     try:
         cmd_args_dict = helper.parse_all_yaml(
-            yaml_files, destroy=delete, targets=targets, sp=sp
+            yaml_files, destroy=delete, targets=targets, target=target, sp=sp
         )
         for block, args_list in cmd_args_dict.items():
             for args in args_list:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -90,6 +90,7 @@ def test_help_flag(runner):
         "--delete",
         "--cli",
         "--targets",
+        "--target",
         "--env-file",
         "--on-exists",
         "--overwrite",
@@ -221,6 +222,39 @@ def test_targets_option(runner, mock_seqera_platform, mock_yaml_processing):
     mock_parse.assert_called_once()
     call_kwargs = mock_parse.call_args[1]
     assert call_kwargs["targets"] == "teams,workspaces"
+
+
+def test_target_option(runner, mock_seqera_platform, mock_yaml_processing):
+    """Test --target option is passed to parse_all_yaml."""
+    mock_find, mock_parse, mock_parser = mock_yaml_processing
+
+    result = runner.invoke(app, ["--target", "pipelines=my-pipeline", "test.yaml"])
+
+    assert result.exit_code == 0
+    mock_parse.assert_called_once()
+    call_kwargs = mock_parse.call_args[1]
+    assert call_kwargs["target"] == ["pipelines=my-pipeline"]
+
+
+def test_multiple_target_options(runner, mock_seqera_platform, mock_yaml_processing):
+    """Test multiple --target options are passed to parse_all_yaml."""
+    mock_find, mock_parse, mock_parser = mock_yaml_processing
+
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            "pipelines=pipeline1",
+            "--target",
+            "compute-envs=ce1",
+            "test.yaml",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_parse.assert_called_once()
+    call_kwargs = mock_parse.call_args[1]
+    assert call_kwargs["target"] == ["pipelines=pipeline1", "compute-envs=ce1"]
 
 
 # OnExists Tests


### PR DESCRIPTION
Adds support for targeting specific resources by name using the new --target flag after some convos with @gwright99. This allows users to selectively create individual resources from a YAML file without processing the entire file.

### Usage
```
# Create a specific pipeline
seqerakit config.yml --target pipelines=my-pipeline

# Create multiple resources by name (comma-separated)
seqerakit config.yml --target pipelines=pipeline1,pipeline2

# Target resources across different types
seqerakit config.yml --target pipelines=my-pipeline --target compute-envs=my-ce
```

Changes

- `cli.py`: Added --target option (can be specified multiple times)
- `helper.py`: Updated parse_all_yaml and parse_yaml_block to filter resources by name
- `README.md:` Documented the new --target flag
- `tests/unit/test_cli.py`: Added tests for CLI argument parsing
- `tests/unit/test_helper.py`: Added tests for name filtering logic