### PR TITLE
fix: datasets resolution to url

### DIFF
--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -183,7 +183,7 @@ def parse_block(block_name, item, sp=None):
         "teams": parse_teams_block,
         "datasets": parse_datasets_block,
         "pipelines": lambda x, s: parse_pipelines_block(x, sp=s),
-        "launch": parse_launch_block,
+        "launch": lambda x, s: parse_launch_block(x, sp=s),
     }
 
     # Use the generic block function as a default.


### PR DESCRIPTION
Fix issue when specifying `dataset: <dataset_name>` does not auto-resolve to its corresponding URL in input params.