### PR TITLE
feat: pass --wait when deleting compute-envs during overwrite

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install Tower CLI
         run: |
-          wget https://github.com/seqeralabs/tower-cli/releases/download/v0.14.0/tw-linux-x86_64 \
+          wget https://github.com/seqeralabs/tower-cli/releases/download/v0.30.0/tw-linux-x86_64 \
           && chmod +x tw-linux-x86_64 \
           && sudo mv tw-linux-x86_64 /usr/local/bin/tw
 

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -351,6 +351,8 @@ class Overwrite:
         arguments defined in the operation dictionary.
         """
         method_args = operation["method_args"](sp_args)
+        if block == "compute-envs":
+            method_args = list(method_args) + ["--wait"]
         method = getattr(self.sp, block)
         method(*method_args)
 

--- a/tests/unit/test_overwrite.py
+++ b/tests/unit/test_overwrite.py
@@ -296,6 +296,46 @@ class TestOverwrite(unittest.TestCase):
             self.overwrite.handle_overwrite("credentials", args3)
 
 
+    def test_delete_resource_compute_envs_includes_wait(self):
+        """Test that deleting compute-envs appends --wait to method args."""
+        operation = {
+            "method_args": lambda args: (
+                "delete",
+                "--name",
+                args["name"],
+                "--workspace",
+                args["workspace"],
+            ),
+        }
+        sp_args = {"name": "test-ce", "workspace": "test-workspace"}
+
+        self.overwrite.delete_resource("compute-envs", operation, sp_args)
+
+        self.mock_sp.compute_envs = self.mock_sp.__getattr__("compute-envs")
+        self.mock_sp.__getattr__("compute-envs").assert_called_with(
+            "delete", "--name", "test-ce", "--workspace", "test-workspace", "--wait"
+        )
+
+    def test_delete_resource_credentials_does_not_include_wait(self):
+        """Test that deleting non-compute-env resources does NOT append --wait."""
+        operation = {
+            "method_args": lambda args: (
+                "delete",
+                "--name",
+                args["name"],
+                "--workspace",
+                args["workspace"],
+            ),
+        }
+        sp_args = {"name": "test-cred", "workspace": "test-workspace"}
+
+        self.overwrite.delete_resource("credentials", operation, sp_args)
+
+        self.mock_sp.__getattr__("credentials").assert_called_with(
+            "delete", "--name", "test-cred", "--workspace", "test-workspace"
+        )
+
+
 # TODO: tests for destroy and JSON caching
 
 if __name__ == "__main__":

--- a/tests/unit/test_overwrite.py
+++ b/tests/unit/test_overwrite.py
@@ -295,7 +295,6 @@ class TestOverwrite(unittest.TestCase):
         with self.assertRaises(ResourceExistsError):
             self.overwrite.handle_overwrite("credentials", args3)
 
-
     def test_delete_resource_compute_envs_includes_wait(self):
         """Test that deleting compute-envs appends --wait to method args."""
         operation = {


### PR DESCRIPTION
## Summary

- When `on_exists: overwrite` deletes a compute environment, appends `--wait` to the `tw compute-envs delete` command
- This blocks until the CE is fully deleted before seqerakit proceeds to create the replacement
- Other resource types (credentials, pipelines, etc.) are unaffected

## Context

Forge CE deletion is async (~2 minutes). seqerakit's overwrite flow deletes the CE and immediately creates the replacement, which fails because the old CE is still in `DELETING` status. Adding `--wait` makes the delete call block until the CE is gone.

**Depends on:** seqeralabs/tower-cli#593 — the tower-cli change must ship first.

Related: FD-7252

## Test plan

- [ ] `test_delete_resource_compute_envs_includes_wait`: verifies `--wait` is appended for compute-envs
- [ ] `test_delete_resource_credentials_does_not_include_wait`: verifies other resources are unaffected
- [ ] Full test suite: 120/120 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)