### PR TITLE
fix: poll for CE deletion instead of tw --wait during overwrite

### DIFF
--- a/docs/design/overwrite-compute-env-deletion-wait.md
+++ b/docs/design/overwrite-compute-env-deletion-wait.md
@@ -55,10 +55,10 @@ The condition that gates a safe recreate is "the name is free to reuse." The
 listing was verified empirically against a live AWS Batch Forge CE in
 `scidev/testing`:
 
-| time after delete | in `compute-envs list` | name reserved (recreate probe) |
-| --- | --- | --- |
-| 1s – 184s (~3 min) | yes, status `DELETING` | yes, recreate rejected |
-| 194s | no, absent | no, recreate succeeded |
+| time after delete  | in `compute-envs list` | name reserved (recreate probe) |
+| ------------------ | ---------------------- | ------------------------------ |
+| 1s – 184s (~3 min) | yes, status `DELETING` | yes, recreate rejected         |
+| 194s               | no, absent             | no, recreate succeeded         |
 
 Listing-absence and name-freedom coincide. The CE stays listed as `DELETING` for
 the full disposal and leaves the listing in the same moment its name frees up,

--- a/docs/design/overwrite-compute-env-deletion-wait.md
+++ b/docs/design/overwrite-compute-env-deletion-wait.md
@@ -1,0 +1,118 @@
+# Wait for compute environment deletion before recreating (`on_exists: overwrite`)
+
+Tracking: FD-7252 / COMP-1531 / COMP-1532
+
+## Problem
+
+A customer using `on_exists: overwrite` for Forge compute environments started
+hitting the AWS Batch limit of 50 managed compute environments. Their CEs were
+being orphaned in AWS instead of cleaned up.
+
+Two separate bugs were involved. The Platform-side bug (silent disposal failures
+leaving orphaned AWS resources) is fixed separately in platform PR #10683. This
+change addresses the seqerakit-side bug.
+
+Since December 2025, Platform deletes Forge CEs asynchronously. A delete marks
+the CE as `DELETING` and tears down the backing cloud resources in the
+background. For AWS Batch Forge this takes roughly 2-3 minutes. While the CE is
+`DELETING`, its name stays reserved.
+
+seqerakit's `on_exists: overwrite` deletes the existing CE and immediately
+creates the replacement. Because the old CE is still `DELETING`, Platform
+rejects the create with an "already exists" error, and the overwrite fails.
+
+## Approaches considered
+
+### A. Append `--wait` to the delete call
+
+`tw compute-envs delete --wait` blocks until the CE reaches a terminal state.
+
+Rejected on compatibility grounds. The `--wait` flag on `compute-envs delete`
+was introduced in tower-cli **0.30.0**. seqerakit runs whatever `tw` is on the
+PATH and documents support for tower-cli **>= 0.11.0**. Appending `--wait`
+unconditionally turns the overwrite into a hard failure for every user on a tw
+older than 0.30.0:
+
+```
+$ tw compute-envs delete --name <ce> -w <ws> --wait
+Unknown option: '--wait'
+```
+
+That converts a race condition into a guaranteed break across the documented
+supported range, which is worse than the bug being fixed.
+
+### B. Poll the workspace listing until the CE disappears (chosen)
+
+After issuing a plain `tw compute-envs delete`, poll `tw compute-envs list`
+until the CE name no longer appears, then proceed to recreate.
+
+This relies only on `compute-envs list`, which has existed since long before the
+supported floor, so it works on any tw version.
+
+## Why polling the listing is a correct signal
+
+The condition that gates a safe recreate is "the name is free to reuse." The
+listing was verified empirically against a live AWS Batch Forge CE in
+`scidev/testing`:
+
+| time after delete | in `compute-envs list` | name reserved (recreate probe) |
+| --- | --- | --- |
+| 1s – 184s (~3 min) | yes, status `DELETING` | yes, recreate rejected |
+| 194s | no, absent | no, recreate succeeded |
+
+Listing-absence and name-freedom coincide. The CE stays listed as `DELETING` for
+the full disposal and leaves the listing in the same moment its name frees up,
+so polling the listing waits exactly as long as the recreate needs and no
+longer. An aws-cloud CE shows the same relationship on a much shorter timescale
+(name freed ~7s).
+
+The observed disposal time of ~194s also sets the timeout. A 180s timeout would
+have failed a healthy deletion; the timeout is set to **300s** to leave headroom.
+
+## Implementation
+
+`seqerakit/overwrite.py`:
+
+- `delete_resource` issues a plain delete (no `--wait`), then calls
+  `_wait_for_ce_deletion` for the `compute-envs` block only. Other resource
+  types are unaffected.
+- `_wait_for_ce_deletion(sp_args, poll_interval=5, timeout=300)` polls
+  `compute-envs list -w <workspace>` every 5s, using a `time.monotonic()`
+  deadline, and returns as soon as the CE name is absent from the listing. It
+  invalidates the cached listing for that workspace on each poll so it sees
+  fresh data. If the deadline passes with the CE still listed, it raises
+  `TimeoutError`.
+
+### Behaviour when disposal fails (ERRORED)
+
+With platform PR #10683, a failed disposal leaves the CE in `ERRORED` rather
+than soft-deleting it. An `ERRORED` CE stays in the listing, so this poll runs
+to the timeout and raises `TimeoutError` instead of recreating on top of a
+half-disposed environment. The error message names both terminal states
+(`DELETING` not finished, or `ERRORED`) so the cause is not misread as a
+timeout-only condition.
+
+## Testing
+
+`tests/unit/test_overwrite.py`:
+
+- `delete_resource` issues a plain delete and calls `_wait_for_ce_deletion` for
+  `compute-envs`, and does not wait for other resource types.
+- `_wait_for_ce_deletion` returns when the CE is absent on the first poll,
+  returns after several polls once the CE disappears, and raises `TimeoutError`
+  (naming both `DELETING` and `ERRORED`) when the CE never disappears.
+
+`time` is patched in the polling tests so they run without real delays.
+
+## Relationship to PR #267
+
+PR #267 implemented approach A (`--wait`) and is already merged to `main` but not
+yet released. This change replaces that implementation with approach B. The
+`--wait` append and its tests are removed. No tagged release contains the
+`--wait` behaviour, so there is no released regression to roll back.
+
+## Rollout
+
+- No tw version bump is required for users; the floor stays at `>= 0.11.0`.
+- The customer can drop the `delete` / `sleep 150` / `create` workaround once a
+  release containing this change is available.

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import time
 from seqerakit import utils
 from seqerakit.seqeraplatform import ResourceExistsError
 from seqerakit.on_exists import OnExists
@@ -351,10 +352,62 @@ class Overwrite:
         arguments defined in the operation dictionary.
         """
         method_args = operation["method_args"](sp_args)
-        if block == "compute-envs":
-            method_args = list(method_args) + ["--wait"]
         method = getattr(self.sp, block)
         method(*method_args)
+
+        if block == "compute-envs":
+            self._wait_for_ce_deletion(sp_args)
+
+    def _wait_for_ce_deletion(self, sp_args, poll_interval=5, timeout=300):
+        """
+        Poll until a compute environment is no longer visible in the Platform
+        workspace listing, which is the point at which its name is free to
+        reuse.
+
+        Forge CE deletion is asynchronous: Platform marks the CE as DELETING and
+        cleans up the backing cloud resources in the background. During this
+        window the CE stays in the workspace listing and its name remains
+        reserved, so an immediate recreate (on_exists: overwrite) fails with an
+        "already exists" error. Verified empirically against AWS Batch Forge: the
+        CE remains listed as DELETING for the full disposal (~3 min) and leaves
+        the listing in the same moment its name frees up.
+
+        Polling the listing keeps this compatible with any tw version, unlike
+        delegating to `tw compute-envs delete --wait`, which only exists in
+        tower-cli >= 0.30.0.
+
+        If disposal fails, Platform leaves the CE in ERRORED status (it stays
+        listed), so this poll runs to the timeout and raises rather than
+        recreating over a half-disposed environment.
+        """
+        name = utils.resolve_env_var(sp_args["name"])
+        workspace = sp_args["workspace"]
+        cache_key = f"compute-envs:{workspace}"
+        deadline = time.monotonic() + timeout
+
+        logging.info(f" Waiting for compute environment '{name}' to be deleted...")
+
+        while time.monotonic() < deadline:
+            time.sleep(poll_interval)
+
+            # Invalidate cache and re-fetch the CE list
+            self.block_jsondata.pop(cache_key, None)
+            json_method = getattr(self.sp, "-o json")
+            with self.sp.suppress_output():
+                self.cached_jsondata = json_method(
+                    "compute-envs", "list", "-w", workspace
+                )
+            self.block_jsondata[cache_key] = self.cached_jsondata
+
+            if not utils.check_if_exists(self.cached_jsondata, "name", name):
+                logging.info(f" Compute environment '{name}' successfully deleted.")
+                return
+
+        raise TimeoutError(
+            f"Timed out after {timeout}s waiting for compute environment "
+            f"'{name}' to be deleted. It is still listed, which means disposal "
+            f"has not finished (DELETING) or has failed (ERRORED)."
+        )
 
     def _get_values_from_cmd_args(self, cmd_args, keys):
         """

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -394,15 +394,13 @@ class Overwrite:
             self.block_jsondata.pop(cache_key, None)
             json_method = getattr(self.sp, "-o json")
             with self.sp.suppress_output():
-                self.cached_jsondata = json_method(
-                    "compute-envs", "list", "-w", workspace
-                )
-            self.block_jsondata[cache_key] = self.cached_jsondata
+                listing = json_method("compute-envs", "list", "-w", workspace)
+            self.block_jsondata[cache_key] = listing
 
             # Check name presence locally to avoid per-poll INFO log spam from
             # check_if_exists; INFO is reserved for start/success/timeout.
-            still_listed = self.cached_jsondata and utils.find_key_value_in_dict(
-                json.loads(self.cached_jsondata), "name", name, return_key=None
+            still_listed = listing and utils.find_key_value_in_dict(
+                json.loads(listing), "name", name, return_key=None
             )
             if not still_listed:
                 logging.info(f" Compute environment '{name}' successfully deleted.")

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -399,7 +399,12 @@ class Overwrite:
                 )
             self.block_jsondata[cache_key] = self.cached_jsondata
 
-            if not utils.check_if_exists(self.cached_jsondata, "name", name):
+            # Check name presence locally to avoid per-poll INFO log spam from
+            # check_if_exists; INFO is reserved for start/success/timeout.
+            still_listed = self.cached_jsondata and utils.find_key_value_in_dict(
+                json.loads(self.cached_jsondata), "name", name, return_key=None
+            )
+            if not still_listed:
                 logging.info(f" Compute environment '{name}' successfully deleted.")
                 return
 

--- a/tests/unit/test_overwrite.py
+++ b/tests/unit/test_overwrite.py
@@ -295,8 +295,9 @@ class TestOverwrite(unittest.TestCase):
         with self.assertRaises(ResourceExistsError):
             self.overwrite.handle_overwrite("credentials", args3)
 
-    def test_delete_resource_compute_envs_includes_wait(self):
-        """Test that deleting compute-envs appends --wait to method args."""
+    @patch.object(Overwrite, "_wait_for_ce_deletion")
+    def test_delete_resource_waits_for_compute_envs(self, mock_wait):
+        """delete_resource issues a plain delete then waits for CE deletion."""
         operation = {
             "method_args": lambda args: (
                 "delete",
@@ -310,13 +311,15 @@ class TestOverwrite(unittest.TestCase):
 
         self.overwrite.delete_resource("compute-envs", operation, sp_args)
 
-        self.mock_sp.compute_envs = self.mock_sp.__getattr__("compute-envs")
+        # plain delete, no --wait flag appended
         self.mock_sp.__getattr__("compute-envs").assert_called_with(
-            "delete", "--name", "test-ce", "--workspace", "test-workspace", "--wait"
+            "delete", "--name", "test-ce", "--workspace", "test-workspace"
         )
+        mock_wait.assert_called_once_with(sp_args)
 
-    def test_delete_resource_credentials_does_not_include_wait(self):
-        """Test that deleting non-compute-env resources does NOT append --wait."""
+    @patch.object(Overwrite, "_wait_for_ce_deletion")
+    def test_delete_resource_does_not_wait_for_credentials(self, mock_wait):
+        """delete_resource does NOT wait when deleting non-compute-env resources."""
         operation = {
             "method_args": lambda args: (
                 "delete",
@@ -333,6 +336,57 @@ class TestOverwrite(unittest.TestCase):
         self.mock_sp.__getattr__("credentials").assert_called_with(
             "delete", "--name", "test-cred", "--workspace", "test-workspace"
         )
+        mock_wait.assert_not_called()
+
+    @patch("seqerakit.overwrite.time")
+    def test_wait_for_ce_deletion_immediate(self, mock_time):
+        """CE absent on the first poll returns without raising."""
+        mock_time.monotonic = Mock(side_effect=[0, 1])  # start, first check
+
+        json_method_mock = Mock(return_value=json.dumps({"computeEnvs": []}))
+        self.mock_sp.configure_mock(**{"-o json": json_method_mock})
+
+        self.overwrite._wait_for_ce_deletion({"name": "my-ce", "workspace": "org/ws"})
+
+        mock_time.sleep.assert_called_with(5)
+        json_method_mock.assert_called_with("compute-envs", "list", "-w", "org/ws")
+
+    @patch("seqerakit.overwrite.time")
+    def test_wait_for_ce_deletion_delayed(self, mock_time):
+        """CE present for several polls, then gone, returns without raising."""
+        # monotonic: start=0, poll1=5, poll2=10, poll3=15
+        mock_time.monotonic = Mock(side_effect=[0, 5, 10, 15])
+
+        ce_present = json.dumps({"computeEnvs": [{"name": "my-ce"}]})
+        ce_gone = json.dumps({"computeEnvs": []})
+
+        json_method_mock = Mock(side_effect=[ce_present, ce_present, ce_gone])
+        self.mock_sp.configure_mock(**{"-o json": json_method_mock})
+
+        self.overwrite._wait_for_ce_deletion({"name": "my-ce", "workspace": "org/ws"})
+
+        assert mock_time.sleep.call_count == 3
+        assert json_method_mock.call_count == 3
+
+    @patch("seqerakit.overwrite.time")
+    def test_wait_for_ce_deletion_timeout(self, mock_time):
+        """CE never disappears: raise TimeoutError naming both terminal states."""
+        # monotonic returns values that exceed the (short) timeout
+        mock_time.monotonic = Mock(side_effect=[0, 5, 11])
+
+        ce_present = json.dumps({"computeEnvs": [{"name": "my-ce"}]})
+        json_method_mock = Mock(return_value=ce_present)
+        self.mock_sp.configure_mock(**{"-o json": json_method_mock})
+
+        with self.assertRaises(TimeoutError) as ctx:
+            self.overwrite._wait_for_ce_deletion(
+                {"name": "my-ce", "workspace": "org/ws"},
+                timeout=10,
+            )
+
+        assert "my-ce" in str(ctx.exception)
+        assert "DELETING" in str(ctx.exception)
+        assert "ERRORED" in str(ctx.exception)
 
 
 # TODO: tests for destroy and JSON caching


### PR DESCRIPTION
## Summary

`on_exists: overwrite` for Forge compute environments deletes the existing CE then immediately recreates it. Since Platform deletion became asynchronous (Dec 2025), the old CE stays in `DELETING` (~2-3 min) with its name reserved, so the recreate fails with "already exists" and AWS resources accumulate (FD-7252).

This replaces the previously merged fix (#267), which appended `--wait` to the `tw compute-envs delete` call. That flag only exists in **tower-cli >= 0.30.0** and hard-fails on the documented supported range (`>= 0.11.0`):

```
$ tw compute-envs delete --name <ce> -w <ws> --wait
Unknown option: '--wait'
```

Instead, after a plain delete, poll `compute-envs list` until the CE name disappears. This uses only `compute-envs list`, so it works on any tw version.

## Why polling the listing is correct

Verified empirically against a live AWS Batch Forge CE in `scidev/testing`:

| time after delete | in `compute-envs list` | name reserved (recreate probe) |
| --- | --- | --- |
| 1s – 184s (~3 min) | yes, `DELETING` | yes, recreate rejected |
| 194s | absent | no, recreate succeeded |

Listing-absence and name-freedom coincide, so the poll waits exactly as long as the recreate needs. The ~194s observed disposal is why the timeout is **300s** (the 180s default would have failed a healthy deletion).

## ERRORED handling

With platform PR #10683, a failed disposal leaves the CE `ERRORED` (still listed), so the poll times out and raises rather than recreating over a half-disposed environment. The `TimeoutError` message names both terminal states.

## Notes

- No tw version bump required for users; floor stays `>= 0.11.0`.
- No tagged release contains the `#267` `--wait` behaviour, so there is no released regression.
- Design doc: `docs/design/overwrite-compute-env-deletion-wait.md`

## Test plan

- [x] `uv run pytest tests/unit` (123 passed)
- [x] `ruff check` / `ruff format --check` with pinned v0.8.3
- [ ] e2e overwrite of an AWS Batch Forge CE on cloud.seqera.io

Refs FD-7252, COMP-1531, COMP-1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)